### PR TITLE
BAN-32: Flex utils

### DIFF
--- a/.storybook/preview.scss
+++ b/.storybook/preview.scss
@@ -1,4 +1,5 @@
 @import '/src/zen-styles/normalize.scss';
+@import '/src/zen-styles/utilities/index.scss';
 
 .zen-app-styles {
   @import '/src/zen-styles/main.scss';

--- a/src/stories/Flex.stories.mdx
+++ b/src/stories/Flex.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import { scssNonNullBreakpoints, scssArrayVar } from './utils/utils';
+import { scssNonNullBreakpoints, scssArrayVar, scssBreakpoint } from './utils/utils';
 const breakpoints = scssNonNullBreakpoints();
 const flexUtils = scssArrayVar('$flex-utils').map(util => ({
   prop: util.value[0].value,
@@ -42,3 +42,14 @@ There's also responsive-friendly version for each class<br/>
   </li>
   ))}
   </ul>
+
+<p>
+  <i>
+    eg.
+    <code>class="flex-direction-row flex-direction-md-column"</code>:
+    Disply items in row, but if screen is wider than
+    <span> { scssBreakpoint('md').value }</span>
+    px, display them in column.
+  </i>
+</p>
+

--- a/src/stories/Flex.stories.mdx
+++ b/src/stories/Flex.stories.mdx
@@ -47,9 +47,9 @@ There's also responsive-friendly version for each class<br/>
   <i>
     eg.
     <code>class="flex-direction-row flex-direction-md-column"</code>:
-    Disply items in row, but if screen is wider than
+    Display items in a row, but if the screen is wider than
     <span> { scssBreakpoint('md').value }</span>
-    px, display them in column.
+    px, display them in the column.
   </i>
 </p>
 

--- a/src/stories/Flex.stories.mdx
+++ b/src/stories/Flex.stories.mdx
@@ -1,4 +1,11 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { scssArrayVar } from './utils/utils';
+const flexUtils = scssArrayVar('$flex-utils').map(util => ({
+  prop: util.value[0].value,
+  propSuffix: util.value[1].value,
+  prop: util.value[2].value,
+  value: util.value[3].value
+}));
 
 <Meta title="Flex" />
 
@@ -10,6 +17,15 @@ Utility classes for standard flex properties.
 *For more info on flexbox layout check [A Complete Guide to Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)*
 
 ### Classes
+<ul>
+  {flexUtils.map(item => (
+  <li key={item.prop + item.propSuffix}>
+    <code>
+      {item.prop}{item.propSuffix}
+    </code> {item.prop}: {item.value} !important
+  </li>
+  ))}
+</ul>
 
 ### Responsive-friendly version
 There's also responsive-friendly version for each class<br/>

--- a/src/stories/Flex.stories.mdx
+++ b/src/stories/Flex.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import { scssArrayVar } from './utils/utils';
+import { scssNonNullBreakpoints, scssArrayVar } from './utils/utils';
+const breakpoints = scssNonNullBreakpoints();
 const flexUtils = scssArrayVar('$flex-utils').map(util => ({
   prop: util.value[0].value,
   propSuffix: util.value[1].value,
@@ -30,3 +31,14 @@ Utility classes for standard flex properties.
 ### Responsive-friendly version
 There's also responsive-friendly version for each class<br/>
 `{property}-{breakpoint}-{value}`
+
+- `breakpoint` is one of:
+  <ul>
+  {breakpoints.map(breakpoint => (
+  <li key={breakpoint.name} style={{'marginLeft': '12px'}}>
+    <code>
+      {breakpoint.name}
+    </code> - on screens wider than {breakpoint.value}px
+  </li>
+  ))}
+  </ul>

--- a/src/stories/Flex.stories.mdx
+++ b/src/stories/Flex.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+
+<Meta title="Flex" />
+
+# Flex
+
+Utility classes for standard flex properties.
+
+*This system is modeled on [Bootstrap flex utilities](https://getbootstrap.com/docs/4.3/utilities/flex/)*<br/>
+*For more info on flexbox layout check [A Complete Guide to Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)*
+
+### Classes
+
+### Responsive-friendly version
+There's also responsive-friendly version for each class<br/>
+`{property}-{breakpoint}-{value}`

--- a/src/stories/Spacing.stories.mdx
+++ b/src/stories/Spacing.stories.mdx
@@ -3,7 +3,6 @@ import { scssNonNullBreakpoints, scssBreakpoint, scssArrayVar } from './utils/ut
 const sassVars = require('sass-extract-loader!../zen-styles/variables.scss');
 const spacers = scssArrayVar('$spacers');
 const breakpoints = scssNonNullBreakpoints();
-console.log(breakpoints);
 
 <Meta title="Spacing" />
 

--- a/src/stories/utils/utils.js
+++ b/src/stories/utils/utils.js
@@ -1,4 +1,4 @@
-const sassVars = require('sass-extract-loader!../../zen-styles/variables.scss');
+const sassVars = require('sass-extract-loader!../../zen-styles/main.scss');
 
 export function scssArrayVar(varName) {
   return Object.entries(sassVars.global[varName].value).map(([key, value]) => ({

--- a/src/zen-styles/utilities/flex.scss
+++ b/src/zen-styles/utilities/flex.scss
@@ -1,0 +1,51 @@
+// stylelint-disable declaration-no-important
+
+// Flex variation
+//
+// Custom styles for additional flex alignment options.
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+    .flex#{$infix}-row            { flex-direction: row !important; }
+    .flex#{$infix}-column         { flex-direction: column !important; }
+    .flex#{$infix}-row-reverse    { flex-direction: row-reverse !important; }
+    .flex#{$infix}-column-reverse { flex-direction: column-reverse !important; }
+
+    .flex#{$infix}-wrap         { flex-wrap: wrap !important; }
+    .flex#{$infix}-nowrap       { flex-wrap: nowrap !important; }
+    .flex#{$infix}-wrap-reverse { flex-wrap: wrap-reverse !important; }
+    .flex#{$infix}-fill         { flex: 1 1 auto !important; }
+    .flex#{$infix}-grow-0       { flex-grow: 0 !important; }
+    .flex#{$infix}-grow-1       { flex-grow: 1 !important; }
+    .flex#{$infix}-shrink-0     { flex-shrink: 0 !important; }
+    .flex#{$infix}-shrink-1     { flex-shrink: 1 !important; }
+
+    .justify-content#{$infix}-start   { justify-content: flex-start !important; }
+    .justify-content#{$infix}-end     { justify-content: flex-end !important; }
+    .justify-content#{$infix}-center  { justify-content: center !important; }
+    .justify-content#{$infix}-between { justify-content: space-between !important; }
+    .justify-content#{$infix}-around  { justify-content: space-around !important; }
+
+    .align-items#{$infix}-start    { align-items: flex-start !important; }
+    .align-items#{$infix}-end      { align-items: flex-end !important; }
+    .align-items#{$infix}-center   { align-items: center !important; }
+    .align-items#{$infix}-baseline { align-items: baseline !important; }
+    .align-items#{$infix}-stretch  { align-items: stretch !important; }
+
+    .align-content#{$infix}-start   { align-content: flex-start !important; }
+    .align-content#{$infix}-end     { align-content: flex-end !important; }
+    .align-content#{$infix}-center  { align-content: center !important; }
+    .align-content#{$infix}-between { align-content: space-between !important; }
+    .align-content#{$infix}-around  { align-content: space-around !important; }
+    .align-content#{$infix}-stretch { align-content: stretch !important; }
+
+    .align-self#{$infix}-auto     { align-self: auto !important; }
+    .align-self#{$infix}-start    { align-self: flex-start !important; }
+    .align-self#{$infix}-end      { align-self: flex-end !important; }
+    .align-self#{$infix}-center   { align-self: center !important; }
+    .align-self#{$infix}-baseline { align-self: baseline !important; }
+    .align-self#{$infix}-stretch  { align-self: stretch !important; }
+  }
+}

--- a/src/zen-styles/utilities/flex.scss
+++ b/src/zen-styles/utilities/flex.scss
@@ -4,48 +4,54 @@
 //
 // Custom styles for additional flex alignment options.
 
+$flex-utils: (
+  ('flex', '-row',                'flex-direction', 'row'),
+  ('flex', '-column',             'flex-direction', 'column'),
+  ('flex', '-row-reverse',        'flex-direction', 'row-reverse'),
+  ('flex', '-column-reverse',     'flex-direction', 'column-reverse'),
+
+  ('flex', '-wrap',               'flex-wrap', 'wrap'),
+  ('flex', '-nowrap',             'flex-wrap', 'nowrap'),
+  ('flex', '-wrap-reverse',       'flex-wrap', 'wrap-reverse'),
+  ('flex', '-fill',               'flex', '1 1 auto'),
+  ('flex', '-grow-0',             'flex-grow', '0'),
+  ('flex', '-grow-1',             'flex-grow', '1'),
+  ('flex', '-shrink-0',           'flex-shrink', '0'),
+  ('flex', '-shrink-1',           'flex-shrink', '1'),
+
+  ('justify-content', '-start',   'justify-content', 'flex-start'),
+  ('justify-content', '-end',     'justify-content', 'flex-end'),
+  ('justify-content', '-center',  'justify-content', 'center'),
+  ('justify-content', '-between', 'justify-content', 'space-between'),
+  ('justify-content', '-around',  'justify-content', 'space-around'),
+
+  ('align-items', '-start',       'align-items', 'flex-start'),
+  ('align-items', '-end',         'align-items', 'flex-end'),
+  ('align-items', '-center',      'align-items', 'center'),
+  ('align-items', '-baseline',    'align-items', 'baseline'),
+  ('align-items', '-stretch',     'align-items', 'stretch'),
+
+  ('align-content', '-start',     'align-content', 'start'),
+  ('align-content', '-end',       'align-content', 'end'),
+  ('align-content', '-center',    'align-content', 'center'),
+  ('align-content', '-between',   'align-content', 'between'),
+  ('align-content', '-around',    'align-content', 'around'),
+  ('align-content', '-stretch',   'align-content', 'stretch'),
+
+  ('align-self', '-auto',          'align-self', 'auto'),
+  ('align-self', '-start',         'align-self', 'start'),
+  ('align-self', '-end',           'align-self', 'end'),
+  ('align-self', '-center',        'align-self', 'center'),
+  ('align-self', '-baseline',      'align-self', 'baseline'),
+  ('align-self', '-stretch',       'align-self', 'stretch'),
+);
+
 @each $breakpoint in map-keys($grid-breakpoints) {
   @include media-breakpoint-up($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
 
-    .flex#{$infix}-row            { flex-direction: row !important; }
-    .flex#{$infix}-column         { flex-direction: column !important; }
-    .flex#{$infix}-row-reverse    { flex-direction: row-reverse !important; }
-    .flex#{$infix}-column-reverse { flex-direction: column-reverse !important; }
-
-    .flex#{$infix}-wrap         { flex-wrap: wrap !important; }
-    .flex#{$infix}-nowrap       { flex-wrap: nowrap !important; }
-    .flex#{$infix}-wrap-reverse { flex-wrap: wrap-reverse !important; }
-    .flex#{$infix}-fill         { flex: 1 1 auto !important; }
-    .flex#{$infix}-grow-0       { flex-grow: 0 !important; }
-    .flex#{$infix}-grow-1       { flex-grow: 1 !important; }
-    .flex#{$infix}-shrink-0     { flex-shrink: 0 !important; }
-    .flex#{$infix}-shrink-1     { flex-shrink: 1 !important; }
-
-    .justify-content#{$infix}-start   { justify-content: flex-start !important; }
-    .justify-content#{$infix}-end     { justify-content: flex-end !important; }
-    .justify-content#{$infix}-center  { justify-content: center !important; }
-    .justify-content#{$infix}-between { justify-content: space-between !important; }
-    .justify-content#{$infix}-around  { justify-content: space-around !important; }
-
-    .align-items#{$infix}-start    { align-items: flex-start !important; }
-    .align-items#{$infix}-end      { align-items: flex-end !important; }
-    .align-items#{$infix}-center   { align-items: center !important; }
-    .align-items#{$infix}-baseline { align-items: baseline !important; }
-    .align-items#{$infix}-stretch  { align-items: stretch !important; }
-
-    .align-content#{$infix}-start   { align-content: flex-start !important; }
-    .align-content#{$infix}-end     { align-content: flex-end !important; }
-    .align-content#{$infix}-center  { align-content: center !important; }
-    .align-content#{$infix}-between { align-content: space-between !important; }
-    .align-content#{$infix}-around  { align-content: space-around !important; }
-    .align-content#{$infix}-stretch { align-content: stretch !important; }
-
-    .align-self#{$infix}-auto     { align-self: auto !important; }
-    .align-self#{$infix}-start    { align-self: flex-start !important; }
-    .align-self#{$infix}-end      { align-self: flex-end !important; }
-    .align-self#{$infix}-center   { align-self: center !important; }
-    .align-self#{$infix}-baseline { align-self: baseline !important; }
-    .align-self#{$infix}-stretch  { align-self: stretch !important; }
+    @each $item in $flex-utils {
+      .#{nth($item, 1)}#{$infix}#{nth($item, 2)} { #{nth($item, 3)}: #{nth($item, 4)} !important; }
+    }
   }
 }

--- a/src/zen-styles/utilities/index.scss
+++ b/src/zen-styles/utilities/index.scss
@@ -1,2 +1,5 @@
+@import "../variables";
+@import "../mixins/breakpoints";
+
 @import "./spacing";
 @import "./flex";

--- a/src/zen-styles/utilities/index.scss
+++ b/src/zen-styles/utilities/index.scss
@@ -1,1 +1,2 @@
 @import "./spacing";
+@import "./flex";


### PR DESCRIPTION
Added flex utility classes.

I've also imported `utilities/index.scss` to Storybook, so we can use all utility classes on Storybook design directly. For now, I'd avoid importing the whole `zen-ui-styles` into the Storybook.

![Screenshot 2020-11-18 at 15 10 08](https://user-images.githubusercontent.com/5729421/99540728-31b72080-29b0-11eb-8e38-d9f3d8bd5261.jpg)
