### PR TITLE
quickfix: cleaned all lint errors and corrected lodash imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@storybook/theming": "~6.1.4",
     "@storybook/web-components": "~6.1.4",
     "@types/jest": "~26.0.15",
+    "@types/lodash": "^4.14.165",
     "@typescript-eslint/eslint-plugin": "~4.9.0",
     "@typescript-eslint/parser": "~4.9.0",
     "autoprefixer": "~10.0.2",
@@ -90,6 +91,7 @@
     "sass-extract-loader": "~1.1.0",
     "sass-loader": "~10.1.0",
     "style-loader": "~2.0.0",
+    "ts-key-enum": "^3.0.4",
     "typescript": "~4.1.2",
     "webpack": "~5.4.0",
     "webpack-cli": "~4.2.0"
@@ -97,8 +99,8 @@
   "license": "MIT",
   "dependencies": {
     "@stencil/core": "~2.3.0",
-    "lodash": "~4.17.20",
-    "ts-key-enum": "^3.0.4"
+    "lodash": "~4.17.20"
+
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@storybook/theming": "~6.1.4",
     "@storybook/web-components": "~6.1.4",
     "@types/jest": "~26.0.15",
-    "@types/lodash": "^4.14.165",
+    "@types/lodash": "~4.14.165",
     "@typescript-eslint/eslint-plugin": "~4.9.0",
     "@typescript-eslint/parser": "~4.9.0",
     "autoprefixer": "~10.0.2",

--- a/src/components/zen-dropdown/zen-dropdown.tsx
+++ b/src/components/zen-dropdown/zen-dropdown.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, State, Event, EventEmitter, Listen, Watch, El
 import { MouseEvent, slotPassed, getSlotElement } from '../helpers/helpers';
 import { faChevronDown } from '@fortawesome/pro-light-svg-icons';
 import { renderIcon, styles } from '../helpers/fa-icons';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { waitNextFrame } from '../helpers/helpers';
 import { Key } from 'ts-key-enum';
 

--- a/src/components/zen-notification/test/zen-notification.spec.tsx
+++ b/src/components/zen-notification/test/zen-notification.spec.tsx
@@ -1,4 +1,3 @@
-import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { ZenNotification } from '../zen-notification';
 

--- a/src/components/zen-notification/zen-notification-helper.ts
+++ b/src/components/zen-notification/zen-notification-helper.ts
@@ -15,7 +15,7 @@ export enum ZenDismissDuration {
   LONG = 'long',
 }
 
-export function getIcon(variant): HTMLElement {
+export function getIcon(variant: ZenVariant): HTMLElement {
   let icon: HTMLElement;
   switch (variant) {
     case ZenVariant.SUCCESS:

--- a/src/components/zen-notification/zen-notification.tsx
+++ b/src/components/zen-notification/zen-notification.tsx
@@ -32,11 +32,11 @@ export class ZenNotification {
   /** Can dismiss */
   @Prop() readonly dismiss: boolean = false;
 
-  close(el) {
+  close(el: HTMLElement): void {
     el.className = '';
   }
 
-  componentDidRender() {
+  componentDidRender(): void {
     if (this.dismissDuration !== ZenDismissDuration.NONE) {
       setTimeout(() => {
         this.close(this.div);

--- a/src/components/zen-steps/zen-steps.tsx
+++ b/src/components/zen-steps/zen-steps.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, State, Event, EventEmitter, Watch } from '@st
 import { faCheck } from '@fortawesome/pro-light-svg-icons';
 import { renderIcon, styles } from '../helpers/fa-icons';
 import { StepsFilter } from './types';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 export interface StepItem {
   label: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2456,6 +2456,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.165":
+  version "4.14.165"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
+  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
+
 "@types/markdown-to-jsx@^6.11.0":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz#cdd1619308fecbc8be7e6a26f3751260249b020e"


### PR DESCRIPTION
Fixed:
- Lodash was bloating our build adding more than 17k lines to the custom elements index.
- Missing types that throw errors on lint.