### PR TITLE
BAN-29: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/)
+
+#### Description
+As per JIRA ticket
+
+#### ChangeLOG
+
+- [ ] I have added all notable deployment/development environment (onprem!) changes to [CHANGELOG.md](https://github.com/reciprocity/zen-ui/blob/main/README.md)
+
+
+#### Useful links
+[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)
+
+[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)
+
+[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)


### PR DESCRIPTION
Add pull request template file. [JIRA](https://reciprocitylabs.atlassian.net/browse/BAN-29)

1. Probably we should have a separate repo for general documentation. Or we add a doc polder to our own? For now i left useful links to point to old ZenGrc repo.

2. The Ticket code should be pulled automatically from the branch name by the jira specification. It issent so it seams like a bug to me. Will check more in depth in a next ticket if this dosent get fixed in some time.

3. Will update change log file link when we have autogenerated change logs. :)