### PR TITLE
Modal windows - POC

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -177,6 +177,10 @@ export namespace Components {
         "required": false;
     }
     interface ZenModal {
+        /**
+          * Set to true to show and false to hide modal
+         */
+        "show": boolean;
     }
     interface ZenNotification {
         /**
@@ -628,6 +632,10 @@ declare namespace LocalJSX {
         "required"?: false;
     }
     interface ZenModal {
+        /**
+          * Set to true to show and false to hide modal
+         */
+        "show"?: boolean;
     }
     interface ZenNotification {
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -176,6 +176,8 @@ export namespace Components {
          */
         "required": false;
     }
+    interface ZenModal {
+    }
     interface ZenNotification {
         /**
           * Can dismiss
@@ -394,6 +396,12 @@ declare global {
         prototype: HTMLZenLabelElement;
         new (): HTMLZenLabelElement;
     };
+    interface HTMLZenModalElement extends Components.ZenModal, HTMLStencilElement {
+    }
+    var HTMLZenModalElement: {
+        prototype: HTMLZenModalElement;
+        new (): HTMLZenModalElement;
+    };
     interface HTMLZenNotificationElement extends Components.ZenNotification, HTMLStencilElement {
     }
     var HTMLZenNotificationElement: {
@@ -450,6 +458,7 @@ declare global {
         "zen-input": HTMLZenInputElement;
         "zen-input-support-text": HTMLZenInputSupportTextElement;
         "zen-label": HTMLZenLabelElement;
+        "zen-modal": HTMLZenModalElement;
         "zen-notification": HTMLZenNotificationElement;
         "zen-option": HTMLZenOptionElement;
         "zen-spinner": HTMLZenSpinnerElement;
@@ -618,6 +627,8 @@ declare namespace LocalJSX {
          */
         "required"?: false;
     }
+    interface ZenModal {
+    }
     interface ZenNotification {
         /**
           * Can dismiss
@@ -770,6 +781,7 @@ declare namespace LocalJSX {
         "zen-input": ZenInput;
         "zen-input-support-text": ZenInputSupportText;
         "zen-label": ZenLabel;
+        "zen-modal": ZenModal;
         "zen-notification": ZenNotification;
         "zen-option": ZenOption;
         "zen-spinner": ZenSpinner;
@@ -796,6 +808,7 @@ declare module "@stencil/core" {
             "zen-input": LocalJSX.ZenInput & JSXBase.HTMLAttributes<HTMLZenInputElement>;
             "zen-input-support-text": LocalJSX.ZenInputSupportText & JSXBase.HTMLAttributes<HTMLZenInputSupportTextElement>;
             "zen-label": LocalJSX.ZenLabel & JSXBase.HTMLAttributes<HTMLZenLabelElement>;
+            "zen-modal": LocalJSX.ZenModal & JSXBase.HTMLAttributes<HTMLZenModalElement>;
             "zen-notification": LocalJSX.ZenNotification & JSXBase.HTMLAttributes<HTMLZenNotificationElement>;
             "zen-option": LocalJSX.ZenOption & JSXBase.HTMLAttributes<HTMLZenOptionElement>;
             "zen-spinner": LocalJSX.ZenSpinner & JSXBase.HTMLAttributes<HTMLZenSpinnerElement>;

--- a/src/components/zen-modal/zen-modal.scss
+++ b/src/components/zen-modal/zen-modal.scss
@@ -1,0 +1,7 @@
+:host {
+
+}
+
+p {
+  background-color: #f00;
+}

--- a/src/components/zen-modal/zen-modal.scss
+++ b/src/components/zen-modal/zen-modal.scss
@@ -1,5 +1,7 @@
 @import '../../zen-styles/variables.scss';
 
+$padding-x: 3.2rem;
+
 :host {
   position: fixed;
   top: 0;
@@ -24,7 +26,15 @@
 .window {
   position: relative;
   background-color: $color-white;
-  padding: 3.2rem;
   border-radius: 3px;
   box-shadow: 2px 6px 30px rgba(#000, 0.2);
+}
+
+.content {
+  padding: 1.6rem $padding-x;
+}
+
+.buttons {
+  padding: 0.8rem $padding-x;
+  border-top: 1px solid $color-gray-200;
 }

--- a/src/components/zen-modal/zen-modal.scss
+++ b/src/components/zen-modal/zen-modal.scss
@@ -1,7 +1,30 @@
-:host {
+@import '../../zen-styles/variables.scss';
 
+:host {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  min-height: 100vh;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-p {
-  background-color: #f00;
+.dimmer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(#000, 0.3);
+}
+
+.window {
+  position: relative;
+  background-color: $color-white;
+  padding: 3.2rem;
+  border-radius: 3px;
+  box-shadow: 2px 6px 30px rgba(#000, 0.2);
 }

--- a/src/components/zen-modal/zen-modal.scss
+++ b/src/components/zen-modal/zen-modal.scss
@@ -12,9 +12,11 @@ $padding-x: 3.2rem;
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
 }
 
-.dimmer {
+:host([topmost]) .dimmer {
+  pointer-events: all;
   position: absolute;
   top: 0;
   left: 0;
@@ -24,6 +26,7 @@ $padding-x: 3.2rem;
 }
 
 .window {
+  pointer-events: all;
   position: relative;
   background-color: $color-white;
   border-radius: 3px;
@@ -37,4 +40,6 @@ $padding-x: 3.2rem;
 .buttons {
   padding: 0.8rem $padding-x;
   border-top: 1px solid $color-gray-200;
+  display: flex;
+  justify-content: flex-end;
 }

--- a/src/components/zen-modal/zen-modal.stories.mdx
+++ b/src/components/zen-modal/zen-modal.stories.mdx
@@ -9,7 +9,30 @@ const argTypes = getArgTypes(compData);
 <Meta title="POC/Modal" component="zen-modal" argTypes={argTypes} />
 
 export const StoryWithControls = args => {
-  return html/*html*/ ` <zen-modal ...="${spreadArgs(args)}"></zen-modal> `;
+  function showModal1() {
+    // close first to enable infinite loop:
+    document.querySelector('#modal1').show = false;
+    document.querySelector('#modal1').show = true;
+  }
+  function showModal2() {
+    document.querySelector('#modal2').show = false;
+    document.querySelector('#modal2').show = true;
+  }
+  return html/*html*/ `
+    <zen-modal id="modal1" ...="${spreadArgs(args)}">
+      <p><b>Modal 1</b></p>
+      <p>This is my modal window 1</p>
+      <zen-input></zen-input>
+      <zen-button @click="${showModal2}">Show Modal 2</zen-button>
+    </zen-modal>
+    <zen-modal id="modal2" ...="${spreadArgs(args)}">
+      <p><b>Modal 2</b></p>
+      <p>Image too large!</p>
+      <zen-button @click="${showModal1}">Show Modal 1</zen-button>
+    </zen-modal>
+    <zen-button @click="${showModal1}">Show Modal 1</zen-button>
+    <zen-button @click="${showModal2}">Show Modal 2</zen-button>
+  `;
 };
 
 # Modal

--- a/src/components/zen-modal/zen-modal.stories.mdx
+++ b/src/components/zen-modal/zen-modal.stories.mdx
@@ -1,0 +1,34 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import { html } from 'lit-html';
+import { getArgTypes, getDefaultArgs, getComponentData, spreadArgs } from '../../../.storybook/helpers/argTypes';
+
+import data from '../../../stencilDocs.json';
+const compData = data.components.find(n => n.tag === 'zen-modal');
+const argTypes = getArgTypes(compData);
+
+<Meta title="POC/Modal" component="zen-modal" argTypes={argTypes} />
+
+export const StoryWithControls = args => {
+  return html/*html*/ ` <zen-modal ...="${spreadArgs(args)}"></zen-modal> `;
+};
+
+# Modal
+
+Standard modal window
+
+## Properties
+
+<Canvas>
+  <Story
+    name="default"
+    args={{
+      ...getDefaultArgs(argTypes),
+    }}
+  >
+    {StoryWithControls.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="default" />
+
+<docs-table docs={JSON.stringify(getComponentData('zen-modal'))}></docs-table>

--- a/src/components/zen-modal/zen-modal.tsx
+++ b/src/components/zen-modal/zen-modal.tsx
@@ -1,4 +1,5 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, Prop, Host, h, Watch, Element } from '@stencil/core';
+import { modalsService } from './zen-modals-service';
 
 @Component({
   tag: 'zen-modal',
@@ -6,18 +7,42 @@ import { Component, Host, h } from '@stencil/core';
   shadow: true,
 })
 export class ZenModal {
+  @Element() hostElement: HTMLZenModalElement;
+
+  /** Set to true to show and false to hide modal */
+  @Prop({ mutable: true }) show = false;
+
+  @Watch('show')
+  async showChanged(show: boolean): Promise<void> {
+    if (show) {
+      modalsService.makeTopmost(this.hostElement);
+    } else {
+      modalsService.modalClosed(this.hostElement);
+    }
+  }
+
+  closeIt(): void {
+    this.show = false;
+  }
+
   render(): HTMLElement {
     return (
       <Host>
-        <div class="dimmer"></div>
-        <div class="window">
-          <div class="content">
-            <slot>Content</slot>
+        {this.show ? (
+          <div>
+            <div class="dimmer"></div>
+            <div class="window">
+              <div class="content">
+                <slot>Content</slot>
+              </div>
+              <div class="buttons">
+                <zen-button onClick={() => this.closeIt()}>Close</zen-button>
+              </div>
+            </div>
           </div>
-          <div class="buttons">
-            <zen-button>Close</zen-button>
-          </div>
-        </div>
+        ) : (
+          ''
+        )}
       </Host>
     );
   }

--- a/src/components/zen-modal/zen-modal.tsx
+++ b/src/components/zen-modal/zen-modal.tsx
@@ -11,7 +11,12 @@ export class ZenModal {
       <Host>
         <div class="dimmer"></div>
         <div class="window">
-          <slot>Content</slot>
+          <div class="content">
+            <slot>Content</slot>
+          </div>
+          <div class="buttons">
+            <zen-button>Close</zen-button>
+          </div>
         </div>
       </Host>
     );

--- a/src/components/zen-modal/zen-modal.tsx
+++ b/src/components/zen-modal/zen-modal.tsx
@@ -1,0 +1,16 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'zen-modal',
+  styleUrl: 'zen-modal.scss',
+  shadow: true,
+})
+export class ZenModal {
+  render(): HTMLElement {
+    return (
+      <Host>
+        <p>Modal</p>
+      </Host>
+    );
+  }
+}

--- a/src/components/zen-modal/zen-modal.tsx
+++ b/src/components/zen-modal/zen-modal.tsx
@@ -1,6 +1,17 @@
 import { Component, Prop, Host, h, Watch, Element } from '@stencil/core';
 import { modalsService } from './zen-modals-service';
 
+declare global {
+  interface Window {
+    ZenModalsService: any;
+  }
+}
+
+// All apps should use the same singletone!
+if (!window.ZenModalsService) {
+  window.ZenModalsService = modalsService;
+}
+
 @Component({
   tag: 'zen-modal',
   styleUrl: 'zen-modal.scss',
@@ -15,9 +26,9 @@ export class ZenModal {
   @Watch('show')
   async showChanged(show: boolean): Promise<void> {
     if (show) {
-      modalsService.makeTopmost(this.hostElement);
+      window.ZenModalsService.makeTopmost(this.hostElement);
     } else {
-      modalsService.modalClosed(this.hostElement);
+      window.ZenModalsService.modalClosed(this.hostElement);
     }
   }
 

--- a/src/components/zen-modal/zen-modal.tsx
+++ b/src/components/zen-modal/zen-modal.tsx
@@ -9,7 +9,10 @@ export class ZenModal {
   render(): HTMLElement {
     return (
       <Host>
-        <p>Modal</p>
+        <div class="dimmer"></div>
+        <div class="window">
+          <slot>Content</slot>
+        </div>
       </Host>
     );
   }

--- a/src/components/zen-modal/zen-modals-service.ts
+++ b/src/components/zen-modal/zen-modals-service.ts
@@ -1,0 +1,26 @@
+export const modalsService = {
+  modals: [],
+  lastZIndex: 100,
+
+  makeTopmost(modal: HTMLZenModalElement): void {
+    this.modals.push(modal);
+    this.updateLayers();
+  },
+  modalClosed(modal: HTMLZenModalElement): void {
+    this.modals = this.modals.filter(n => !n.isSameNode(modal));
+    this.updateLayers();
+  },
+  updateLayers(): void {
+    const setHighestZIndex = (modal: HTMLZenModalElement) => (modal.style.zIndex = (this.lastZIndex++).toString());
+    const toggleDimmer = (modal: HTMLZenModalElement, show: boolean) =>
+      show ? topmost.setAttribute('topmost', true) : modal.removeAttribute('topmost');
+
+    this.modals.forEach((modal: HTMLZenModalElement) => {
+      toggleDimmer(modal, false);
+    });
+    const topmost = this.modals[this.modals.length - 1];
+    if (!topmost) return;
+    setHighestZIndex(topmost);
+    toggleDimmer(topmost, true);
+  },
+};


### PR DESCRIPTION
POC for `Zen-modal` component.

Check story POC - Modal

Missing a lot of useful props and styles, but it correctly shows the last opened window on top regardless of its position in the dom.

In the end, I thought it would be more appropriate to let the modal's parent controls the opened state through its `show` prop instead of dispatching events. It seems more natural.

A good thing is that everything stays in its place and thus reactive frameworks could easily be applied to modals content.

Global var `window.ZenModalsService` is used to ensure all apps will use the same service when showing modals.

If you're ok with this global service var, the same approach could easily be applied to the notifications stack.
The beauty of this is that consumers don't need to care about what and when to initialize. Nor we need to think about who should own the notifications/modals service.