### PR TITLE
PLAT-617: Removed bottom padding that overlaps other components when dropdown is closed

### DIFF
--- a/src/components/zen-dropdown/zen-dropdown.scss
+++ b/src/components/zen-dropdown/zen-dropdown.scss
@@ -71,7 +71,6 @@ $field-height: #{1.2rem + 2 * 0.5rem};
   left: -24px;
   padding-right: 24px;
   padding-left: 24px;
-  padding-bottom: 24px;
   overflow: hidden;
   z-index: 100;
 


### PR DESCRIPTION
[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-617)

https://user-images.githubusercontent.com/48444599/106124948-68d94900-613a-11eb-9799-b43b1d0fc444.mov

#### Description
As per JIRA ticket

#### ChangeLOG

- [ ] I have added all notable deployment/development environment (onprem!) changes to [CHANGELOG.md](https://github.com/reciprocity/zen-ui/blob/main/README.md)


#### Useful links
[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)

[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)

[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)
