### PR TITLE
QUICKFIX: Add waitForElement helper function

### DIFF
--- a/.storybook/helpers/utils.js
+++ b/.storybook/helpers/utils.js
@@ -14,3 +14,15 @@ export function camelKeysToKebab(object) {
   }
   return obj;
 }
+
+export function waitForObject(selector, callback) {
+  function afterRender() {
+    const element = document.querySelector(selector);
+    if (!element) return;
+    observer.disconnect();
+    callback(element);
+  }
+
+  const observer = new MutationObserver(afterRender);
+  observer.observe(document.body, { subtree: true, childList: true });
+}

--- a/.storybook/helpers/utils.js
+++ b/.storybook/helpers/utils.js
@@ -15,7 +15,7 @@ export function camelKeysToKebab(object) {
   return obj;
 }
 
-export function waitForObject(selector, callback) {
+export function waitForElement(selector, callback) {
   function afterRender() {
     const element = document.querySelector(selector);
     if (!element) return;

--- a/src/components/zen-steps/zen-steps.stories.mdx
+++ b/src/components/zen-steps/zen-steps.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { html } from 'lit-html';
 import { action } from '../../../.storybook/helpers/custom-action';
 import { getArgTypes, getDefaultArgs, getComponentData, spreadArgs } from '../../../.storybook/helpers/argTypes';
+import { waitForObject } from '../../../.storybook/helpers/utils';
 
 import data from '../../../stencilDocs.json';
 const compData = data.components.find(n => n.tag === 'zen-steps');
@@ -10,14 +11,11 @@ const argTypes = getArgTypes(compData);
 <Meta title="Navigation/Steps" component="zen-steps" argTypes={argTypes} />
 
 export const StoryWithControls = args => {
-  let stepsArr;
-  try {
-    stepsArr = JSON.parse(args.steps);
-  } catch (error) {
-    stepsArr = [];
-  }
+  waitForObject('#steps1', component => {
+    component.steps = args.steps;
+  });
   return html/*html*/ `
-    <zen-steps id="steps1" ...="${spreadArgs(args)}" .steps=${stepsArr} />
+    <zen-steps id="steps1" ...="${spreadArgs(args)}" />
     ${action('#steps1', ['blur', 'focus', 'click', 'change'])}
   `;
 };
@@ -35,12 +33,12 @@ Visualizes user's progress
       ...getDefaultArgs(argTypes),
       // override some default values:
       activeIndex: 1,
-      steps: JSON.stringify([
+      steps: [
         { label: 'Choose framework', completed: true },
         { label: 'Select objectives', completed: true },
         { label: 'Invite teammates', completed: true },
         { label: 'Launch' },
-      ]),
+      ],
     }}
   >
     {StoryWithControls.bind({})}

--- a/src/components/zen-steps/zen-steps.stories.mdx
+++ b/src/components/zen-steps/zen-steps.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { html } from 'lit-html';
 import { action } from '../../../.storybook/helpers/custom-action';
 import { getArgTypes, getDefaultArgs, getComponentData, spreadArgs } from '../../../.storybook/helpers/argTypes';
-import { waitForObject } from '../../../.storybook/helpers/utils';
+import { waitForElement } from '../../../.storybook/helpers/utils';
 
 import data from '../../../stencilDocs.json';
 const compData = data.components.find(n => n.tag === 'zen-steps');
@@ -11,8 +11,8 @@ const argTypes = getArgTypes(compData);
 <Meta title="Navigation/Steps" component="zen-steps" argTypes={argTypes} />
 
 export const StoryWithControls = args => {
-  waitForObject('#steps1', component => {
-    component.steps = args.steps;
+  waitForElement('#steps1', element => {
+    element.steps = args.steps;
   });
   return html/*html*/ `
     <zen-steps id="steps1" ...="${spreadArgs(args)}" />


### PR DESCRIPTION
Helper function waitForElement should be used inside stories to do some js after story has been rendered.
Such as appending /array props to web components. Eg. `document.querySelector('#steps').steps = args.steps`