### PR TITLE
QUICKFIX: input's prop enterToTab can't be set to false from storybook

### DIFF
--- a/.storybook/helpers/argTypes.js
+++ b/.storybook/helpers/argTypes.js
@@ -77,9 +77,10 @@ export function getArgTypesAndArgs(componentName) {
 
 export function spreadArgs(args, argTypes) {
   const isTrueByDefault = (prop) => {
-    return argTypes && argTypes[camelCase(prop)] && argTypes[camelCase(prop)].defaultValue === true;
+    return argTypes[camelCase(prop)] && argTypes[camelCase(prop)].defaultValue === true;
   }
 
+  if (!argTypes) throw('argTypes.js: spreadArgs missing argTypes param');
   const attrs = camelKeysToKebab(args);
   for (const key in attrs) {
     if (!attrs.hasOwnProperty(key)) continue;

--- a/.storybook/helpers/argTypes.js
+++ b/.storybook/helpers/argTypes.js
@@ -1,6 +1,7 @@
 import stencilDocs from '../../stencilDocs.json';
 import { spread } from '@open-wc/lit-helpers';
 import { camelKeysToKebab } from './utils';
+import { camelCase } from 'lodash';
 
 export function getComponentData(componentName) {
   return stencilDocs.components.find(n => n.tag === componentName);
@@ -74,11 +75,15 @@ export function getArgTypesAndArgs(componentName) {
   }
 }
 
-export function spreadArgs(args) {
+export function spreadArgs(args, argTypes) {
+  const isTrueByDefault = (prop) => {
+    return argTypes && argTypes[camelCase(prop)] && argTypes[camelCase(prop)].defaultValue === true;
+  }
+
   const attrs = camelKeysToKebab(args);
   for (const key in attrs) {
     if (!attrs.hasOwnProperty(key)) continue;
-    attrs[key] = attrs[key] === false ? null : attrs[key];
+    attrs[key] = attrs[key] === false && !isTrueByDefault(key) ? null : attrs[key];
   }
   return spread(attrs);
 }

--- a/src/componentTemplate.stories.mdx.sample
+++ b/src/componentTemplate.stories.mdx.sample
@@ -10,7 +10,7 @@ const argTypes = getArgTypes(compData);
 <Meta title="Developers/Template" component="zen-button" argTypes={argTypes} />
 
 export const StoryWithControls = args => html/*html*/ `
-  <zen-button id="button1" ...="${spreadArgs(args)}"> Button 1 </zen-button>
+  <zen-button id="button1" ...="${spreadArgs(args, argTypes)}"> Button 1 </zen-button>
   ${action('#button1', eventHandles(['click']))}
 `;
 

--- a/src/components/zen-avatar-icon/zen-avatar-icon.stories.mdx
+++ b/src/components/zen-avatar-icon/zen-avatar-icon.stories.mdx
@@ -10,7 +10,8 @@ argTypes['color'].control = 'color';
 
 <Meta title="Icons/Avatar Icon" component="zen-avatar-icon" argTypes={argTypes} />
 
-export const StoryWithControls = args => html/*html*/ ` <zen-avatar-icon ...="${spreadArgs(args)}"></zen-avatar-icon>`;
+export const StoryWithControls = args =>
+  html/*html*/ ` <zen-avatar-icon ...="${spreadArgs(args, argTypes)}"></zen-avatar-icon>`;
 
 export const StoryAvatarVariants = () =>
   html/*html*/ `

--- a/src/components/zen-button/zen-button.stories.mdx
+++ b/src/components/zen-button/zen-button.stories.mdx
@@ -11,7 +11,8 @@ import { faChevronDown, faUser } from '@fortawesome/pro-light-svg-icons';
 
 <Meta title="Buttons/Button" component="zen-button" argTypes={argTypes} />
 
-export const StoryWithControls = args => html/*html*/ ` <zen-button ...="${spreadArgs(args)}">Button</zen-button>`;
+export const StoryWithControls = args =>
+  html/*html*/ ` <zen-button ...="${spreadArgs(args, argTypes)}">Button</zen-button>`;
 
 export const StorySimple = () =>
   html/*html*/ `

--- a/src/components/zen-card/zen-card.stories.mdx
+++ b/src/components/zen-card/zen-card.stories.mdx
@@ -27,7 +27,7 @@ export const Story2 = () => {
 };
 
 export const StoryWithControls = args => html/*html*/ `
-  <zen-card id="card0" ...="${spreadArgs(args)}">
+  <zen-card id="card0" ...="${spreadArgs(args, argTypes)}">
     <div style="padding: 1rem;">Content</div>
   </zen-card>
   ${action('#card1', eventHandles(['click']))}

--- a/src/components/zen-checkbox/zen-checkbox.stories.mdx
+++ b/src/components/zen-checkbox/zen-checkbox.stories.mdx
@@ -10,7 +10,7 @@ const argTypes = getArgTypes(compData);
 <Meta title="Forms/Checkbox" component="zen-checkbox" argTypes={argTypes} />
 
 export const StoryWithControls = args => html/*html*/ `
-  <zen-checkbox id="story-with-ctrls-element" ...="${spreadArgs(args)}"></zen-checkbox>
+  <zen-checkbox id="story-with-ctrls-element" ...="${spreadArgs(args, argTypes)}"></zen-checkbox>
   ${action('#story-with-ctrls-element', ['change', 'click'])}
 `;
 

--- a/src/components/zen-form-group/zen-form-group.stories.mdx
+++ b/src/components/zen-form-group/zen-form-group.stories.mdx
@@ -12,7 +12,7 @@ const argTypes = getArgTypes(compData);
 
 export const StoryWithControls = args => {
   return html/*html*/ `
-    <zen-form-group ...=${spreadArgs(args)}>
+    <zen-form-group ...=${spreadArgs(args, argTypes)}>
       <zen-text variant="label" required>Username</zen-text>
       <zen-input></zen-input>
       <zen-text variant="support">This field should be unique</zen-text>

--- a/src/components/zen-icon/zen-icon.stories.mdx
+++ b/src/components/zen-icon/zen-icon.stories.mdx
@@ -15,7 +15,7 @@ export const StoryDefault = args => {
   waitForElement('#zen-icon-element', element => {
     element.icon = args.icon;
   });
-  return html/*html*/ ` <zen-icon id="zen-icon-element" ...="${spreadArgs(args)}"></zen-icon> `;
+  return html/*html*/ ` <zen-icon id="zen-icon-element" ...="${spreadArgs(args, argTypes)}"></zen-icon> `;
 };
 
 # Icon

--- a/src/components/zen-input/zen-input.stories.mdx
+++ b/src/components/zen-input/zen-input.stories.mdx
@@ -14,7 +14,7 @@ import { faUser, faKey, faSearch } from '@fortawesome/pro-light-svg-icons';
 <Meta title="Forms/Input" component="zen-input" argTypes={argTypes} />
 
 export const StoryWithControls = args => html/*html*/ `
-  <zen-input id="input1" style="max-width: 300px" ...="${spreadArgs(args)}"></zen-input>
+  <zen-input id="input1" style="max-width: 300px" ...="${spreadArgs(args, argTypes)}"></zen-input>
   ${action('#input1', ['blur', 'focus', 'input', 'change'])}
 `;
 

--- a/src/components/zen-menu-item/zen-option.stories.mdx
+++ b/src/components/zen-menu-item/zen-option.stories.mdx
@@ -67,7 +67,7 @@ You can wrap any content within zen-option. Here we've added custom png icon, so
 ## Properties
 
 export const Template = args => html/*html*/ `
-  <zen-option default-padding="false" ...="${spreadArgs(args)}"> Dropdown option </zen-option>
+  <zen-option default-padding="false" ...="${spreadArgs(args, argTypes)}"> Dropdown option </zen-option>
 `;
 
 <Canvas>

--- a/src/components/zen-notification/zen-notification.stories.mdx
+++ b/src/components/zen-notification/zen-notification.stories.mdx
@@ -8,7 +8,7 @@ const argTypes = getArgTypes(compData);
 
 <Meta title="Notifications/Notification" component="zen-notification" argTypes={argTypes} />
 
-export const StoryWithControls = args => html/*html*/ ` <zen-notification ...="${spreadArgs(args)}" /> `;
+export const StoryWithControls = args => html/*html*/ ` <zen-notification ...="${spreadArgs(args, argTypes)}" /> `;
 
 export const StoryVariants = () => html/*html*/ ` <div>
     <zen-notification

--- a/src/components/zen-progress-tracker/zen-progress-tracker.stories.mdx
+++ b/src/components/zen-progress-tracker/zen-progress-tracker.stories.mdx
@@ -15,7 +15,7 @@ export const StoryWithControls = args => {
     element.steps = args.steps;
   });
   return html/*html*/ `
-    <zen-progress-tracker id="progress-tracker" ...="${spreadArgs(args)}" />
+    <zen-progress-tracker id="progress-tracker" ...="${spreadArgs(args, argTypes)}" />
     ${action('#progress-tracker', ['blur', 'focus', 'click', 'change'])}
   `;
 };

--- a/src/components/zen-spinner/zen-spinner.stories.mdx
+++ b/src/components/zen-spinner/zen-spinner.stories.mdx
@@ -9,7 +9,7 @@ const argTypes = getArgTypes(compData);
 <Meta title="Icons/Spinner" component="zen-spinner" argTypes={argTypes} />
 
 export const StoryWithControls = args => {
-  return html/*html*/ ` <zen-spinner ...="${spreadArgs(args)}"></zen-spinner> `;
+  return html/*html*/ ` <zen-spinner ...="${spreadArgs(args, argTypes)}"></zen-spinner> `;
 };
 
 export const StoryColors = () => {

--- a/src/components/zen-table/zen-table.stories.mdx
+++ b/src/components/zen-table/zen-table.stories.mdx
@@ -186,7 +186,7 @@ export const Story3 = () => {
 };
 
 export const StoryWithControls = args => html/*html*/ `
-  <zen-table id="table2" ...="${spreadArgs(args)}">
+  <zen-table id="table2" ...="${spreadArgs(args, argTypes)}">
     <zen-table-header>
       <zen-table-header-cell>Title 1</zen-table-header-cell>
       <zen-table-header-cell>Title 2</zen-table-header-cell>

--- a/src/components/zen-text/zen-text.stories.mdx
+++ b/src/components/zen-text/zen-text.stories.mdx
@@ -9,7 +9,7 @@ const argTypes = getArgTypes(compData);
 <Meta title="Typography/Text" component="zen-text" argTypes={argTypes} />
 
 export const StoryWithControls = args => {
-  return html/*html*/ `<zen-text ...="${spreadArgs(args)}">Sample text of Zen-text component</zen-text> `;
+  return html/*html*/ `<zen-text ...="${spreadArgs(args, argTypes)}">Sample text of Zen-text component</zen-text> `;
 };
 
 export const StorySizes = () => html/*html*/ `

--- a/src/components/zen-textarea/zen-textarea.stories.mdx
+++ b/src/components/zen-textarea/zen-textarea.stories.mdx
@@ -10,7 +10,7 @@ const argTypes = getArgTypes(compData);
 <Meta title="Forms/Textarea" component="zen-textarea" argTypes={argTypes} />
 
 export const StoryWithControls = args => html/*html*/ `
-  <zen-textarea id="textarea1" ...="${spreadArgs(args)}" />
+  <zen-textarea id="textarea1" ...="${spreadArgs(args, argTypes)}" />
   ${action('#textarea1', ['blur', 'focus', 'input', 'change'])}
 `;
 

--- a/src/components/zen-tooltip/zen-tooltip.stories.mdx
+++ b/src/components/zen-tooltip/zen-tooltip.stories.mdx
@@ -10,7 +10,7 @@ export const Template = args => {
   return html/*html*/ `
     <div style="text-align: center" class="my-48">
       <zen-button style="display:inline-block" label="Apply changes" variant="secondary"></zen-button>
-      <zen-tooltip ...="${spreadArgs(args)}"></zen-tooltip>
+      <zen-tooltip ...="${spreadArgs(args, argTypes)}"></zen-tooltip>
     </div>
   `;
 };


### PR DESCRIPTION
**To reproduce:**
![Screenshot 2021-02-03 at 08 28 36](https://user-images.githubusercontent.com/5729421/106713072-3035e580-65fa-11eb-924e-6b2efacf28e3.jpg)

**Bug**
Even if enterToTab is `false`, pressing `enter` key will still move focus to the next control.

**Expected**
Nothing should happen on pressing `enter`

**Reason**
If prop is set to false, we're internally set it to `null` in the spreadArgs function. This means it won't render the attribute. It's expected behaviour most of the time: If we want normal text, we just say `<zen-text />`. if we want bold text, we say `<zen-text bold />`. Being obliged to always write `<zen-text bold="false" />` is tedious.
But with props that are `true` by default we shouldn't do that. It's expected that user will explicitly have to turn it off by saying just that: `<zen-input tab-to-enter="false" />`. If he says just `<zen-input />`, `tabToEnter` will default to `true`. And this is what happened in this case: when `tabToEnter` was set to `true`, it was true. When it was set to `false`, attr was removed and it defaulted to `true` again.

**Solution**
If prop is `true` by default, spreadArgs should never remove the attr, but set `prop="true"` or `prop="false"` instead.