### PR TITLE
VRT: Enable parallel runs for VRT tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
         environment:
           # enable colors in output
           TERM: xterm
+    parallelism: 5
     steps:
       - checkout
       - restore_cache:

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "projectId": "iqmzqy",
   "baseUrl": "http://localhost:6006",
   "includeShadowDom": true,
   "video": false,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:e2e:interactive": "cypress open --browser chrome",
     "test:e2e:headless": "docker run -it -v $PWD:/cypress -w /cypress cypress/included:6.2.1 --headless --browser chrome --config baseUrl=http://host.docker.internal:6006",
     "test:e2e:update": "docker run -it -e CYPRESS_updateSnapshots=true -v $PWD:/cypress -w /cypress cypress/included:6.2.1 --headless --browser chrome --config baseUrl=http://host.docker.internal:6006",
-    "test:e2e:ci": "cypress run --headless --browser chrome",
+    "test:e2e:ci": "cypress run --headless --browser chrome --record --parallel",
     "test:vrt": "yarn run test:e2e:headless --spec 'cypress/integration/visual/**'",
     "test:vrt:update": "yarn test:e2e:update --spec 'cypress/integration/visual/**'",
     "create-component": "stencil generate",


### PR DESCRIPTION
[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/)

#### Description
I have added the Circle CI env variable CYPRESS_RECORD_KEY so we can record test runs on the cypress dashboard and use the cypress built-in parallel run. Latter when we will have more E2E tests to run and not enough space for recording  I will make a parallel run using the Circle CI only and different reported where we can follow the test statistics etc. But for now we have a cypress dashboard for that.  

#### ChangeLOG

- [ ] I have added all notable deployment/development environment (onprem!) changes to [CHANGELOG.md](https://github.com/reciprocity/zen-ui/blob/main/README.md)


#### Useful links
[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)

[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)

[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)
