### PR TITLE
PLAT-1141: Fix issue in Firefox with header border displayed on bottom of table as well

### DIFF
--- a/src/components/zen-table-header/zen-table-header.scss
+++ b/src/components/zen-table-header/zen-table-header.scss
@@ -1,3 +1,4 @@
 :host {
   display: table-row;
+  position: relative;
 }


### PR DESCRIPTION
[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-1141)

#### Description
Funny how rendering works...

Before:
![Screenshot 2021-02-09 at 11 25 34](https://user-images.githubusercontent.com/9392804/107350363-a2f70300-6ac9-11eb-9415-c5346ef624c2.png)

After:
![Screenshot 2021-02-09 at 11 24 56](https://user-images.githubusercontent.com/9392804/107350388-aa1e1100-6ac9-11eb-9019-2c88a30e6432.png)

#### ChangeLOG

- [ ] I have added all notable deployment/development environment (onprem!) changes to [CHANGELOG.md](https://github.com/reciprocity/zen-ui/blob/main/README.md)


#### Useful links
[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)

[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)

[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)
