### PR TITLE
PLAT-1122: ZenUI Tooltip does not hide

### DIFF
--- a/src/components/zen-tooltip/zen-tooltip.tsx
+++ b/src/components/zen-tooltip/zen-tooltip.tsx
@@ -112,7 +112,8 @@ export class ZenTooltip {
 
   debounceShow = debounce(this.show, this.showDelay);
 
-  delay = this.maxHeight != 'none' ? Math.max(this.hideDelay, 150) : this.hideDelay;
+  minDelay = this.maxHeight === 'none' ? 150 : 20; // should be async!
+  delay = Math.max(this.hideDelay, this.minDelay);
   debounceHide = debounce(this.hide, this.delay);
 
   componentDidLoad(): void {
@@ -150,9 +151,7 @@ export class ZenTooltip {
       if (!el) continue;
       el.addEventListener('mousemove', (event: MouseEvent) => show(event));
       el.addEventListener('touchstart', () => show());
-      el.addEventListener('mouseout', (event: MouseEvent) => {
-        // filter events bubbling from children:
-        if (event.target !== tooltip && event.target !== previousElement) return;
+      el.addEventListener('mouseout', () => {
         hide();
       });
       el.addEventListener('touchcancel', () => hide());

--- a/src/components/zen-tooltip/zen-tooltip.tsx
+++ b/src/components/zen-tooltip/zen-tooltip.tsx
@@ -112,7 +112,7 @@ export class ZenTooltip {
 
   debounceShow = debounce(this.show, this.showDelay);
 
-  minDelay = this.maxHeight === 'none' ? 150 : 20; // should be async!
+  minDelay = this.maxHeight === 'none' ? 150 : 0; // should be async!
   delay = Math.max(this.hideDelay, this.minDelay);
   debounceHide = debounce(this.hide, this.delay);
 


### PR DESCRIPTION
[jira](https://reciprocitylabs.atlassian.net/browse/PLAT-1122)

Problem was that mouse-out happened only on the trigger element and tooltip parent element. If some child element (like some span inside tooltip), was touching the edge of the tooltip, mouse-out occurred only on this child span and not on tooltip parent (because mouse never hovered over it).
fix: mouse-out is also listened on children elements
