### PR TITLE
QUICK-FIX: Add missing typings

### DIFF
--- a/src/components/zen-avatar-icon/zen-avatar-icon.tsx
+++ b/src/components/zen-avatar-icon/zen-avatar-icon.tsx
@@ -49,7 +49,7 @@ export class ZenAvatarIcon {
     return initials;
   }
 
-  render() {
+  render(): HTMLElement {
     return (
       <Host style={{ background: this.background, color: this.color }}>
         <img class={{ hidden: !this.hasImage() }} src={this.imageUrl} />

--- a/src/stories/components/docs-table/docs-table.tsx
+++ b/src/stories/components/docs-table/docs-table.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop } from '@stencil/core';
-import { JsonDocsComponent, JsonDocsEvent } from '@stencil/core/internal/stencil-public-docs';
+import { JsonDocsComponent, JsonDocsEvent, JsonDocsTag } from '@stencil/core/internal/stencil-public-docs';
 
 @Component({
   tag: 'docs-table',
@@ -12,7 +12,7 @@ export class DocsTable {
   /** Data from stencilDocs.json */
   @Prop() readonly docs: string;
 
-  docTagToCustomEvent(docTag): JsonDocsEvent {
+  docTagToCustomEvent(docTag: JsonDocsTag): JsonDocsEvent {
     const params = docTag.text.split('|');
     return {
       event: (params[0] || '').trim(),

--- a/src/stories/components/html-playground/html-playground.tsx
+++ b/src/stories/components/html-playground/html-playground.tsx
@@ -3,6 +3,11 @@ import { indent, unindent } from './helpers';
 
 declare global {
   interface Window {
+    /**
+     * Disabling since the playground is meant as a POC for now.
+     * Vue typings should later be added if we decide to improve it further.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Vue: any;
   }
 }


### PR DESCRIPTION
#### Description
PR addresses these warnings when linting the code:
```
 % yarn lint
yarn run v1.22.4
$ eslint --fix --ext .js,.ts,.tsx src/

/Users/mplesec/Workspace/reciprocity/zen-ui/src/components/zen-avatar-icon/zen-avatar-icon.tsx
  52:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types

/Users/mplesec/Workspace/reciprocity/zen-ui/src/stories/components/docs-table/docs-table.tsx
  15:23  warning  Argument 'docTag' should be typed  @typescript-eslint/explicit-module-boundary-types

/Users/mplesec/Workspace/reciprocity/zen-ui/src/stories/components/html-playground/html-playground.tsx
  6:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 3 problems (0 errors, 3 warnings)

✨  Done in 5.57s.
```


#### ChangeLOG

- [ ] I have added all notable deployment/development environment (onprem!) changes to [CHANGELOG.md](https://github.com/reciprocity/zen-ui/blob/main/README.md)


#### Useful links
[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)

[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)

[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)
