### PR TITLE
PLAT-1223: Tooltip on scroll content hides the tooltip

### DIFF
--- a/src/components/zen-tooltip/zen-tooltip.tsx
+++ b/src/components/zen-tooltip/zen-tooltip.tsx
@@ -150,6 +150,7 @@ export class ZenTooltip {
     for (const el of [tooltip, previousElement]) {
       if (!el) continue;
       el.addEventListener('mousemove', (event: MouseEvent) => show(event));
+      el.addEventListener('mouseover', (event: MouseEvent) => show(event));
       el.addEventListener('touchstart', () => show());
       el.addEventListener('mouseout', () => {
         hide();


### PR DESCRIPTION
- the problem was that mousemove doesn't occur if mouse is stall and content underneath mouse pointer is scrolled