### PR TITLE
QUICK-FIX: Add name attribute to ZenDropdown

### DIFF
--- a/src/components/zen-dropdown/zen-dropdown.tsx
+++ b/src/components/zen-dropdown/zen-dropdown.tsx
@@ -29,6 +29,8 @@ export class ZenDropdown {
 
   @State() opened = false;
 
+  /** Name of element, can be used as reference for form data */
+  @Prop() readonly name: string = '';
   /** Selected option */
   @Prop({ mutable: true }) value: OptionValue = undefined;
   /** Alignment of field content and menu (if menuWidth set). */


### PR DESCRIPTION
#### Description
PR adds the name attribute, since it's the default way for referencing this element in forms. See: https://www.w3schools.com/tags/tag_select.asp

#### ChangeLOG

[Changelog](https://zen-ui.zengrc.com/?path=/docs/changelog--page)


#### Useful links
[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)

[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)

[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)
