### PR TITLE
PLAT-1242: Increase the width of the progress tracker labels

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -408,6 +408,10 @@ export namespace Components {
          */
         "clickable": StepsFilter;
         /**
+          * Max label width
+         */
+        "labelWidth": string;
+        /**
           * Ordered array of possible steps
          */
         "steps": Array<StepItem>;
@@ -1320,6 +1324,10 @@ declare namespace LocalJSX {
           * User can click step to go to step
          */
         "clickable"?: StepsFilter;
+        /**
+          * Max label width
+         */
+        "labelWidth"?: string;
         /**
           * Ordered array of possible steps
          */

--- a/src/components/zen-progress-tracker/zen-progress-tracker.scss
+++ b/src/components/zen-progress-tracker/zen-progress-tracker.scss
@@ -43,7 +43,6 @@
     left: 50%;
     transform: translate(-50%, 0);
     padding-top: 1.2em;
-    width: 8rem;
     text-align: center;
 
     font-size: $text-sm;

--- a/src/components/zen-progress-tracker/zen-progress-tracker.spec.tsx
+++ b/src/components/zen-progress-tracker/zen-progress-tracker.spec.tsx
@@ -45,7 +45,7 @@ describe('zen-progress-tracker', () => {
           <div class="roundle">
             <div>1</div>
           </div>
-          <div class="label">Step one</div>
+          <div class="label" style="width: 8rem;">Step one</div>
         </li>
       </ul>`);
   });

--- a/src/components/zen-progress-tracker/zen-progress-tracker.tsx
+++ b/src/components/zen-progress-tracker/zen-progress-tracker.tsx
@@ -31,6 +31,8 @@ export class ZenProgressTracker {
   @Prop({ reflect: true }) readonly activeIndex: number = 0;
   /** User can click step to go to step */
   @Prop({ reflect: true }) readonly clickable: StepsFilter = 'completed';
+  /** Max label width */
+  @Prop({ reflect: true }) readonly labelWidth: string = '8rem';
 
   @Watch('activeIndex')
   activeIndexChanged(activeIndex: number): void {
@@ -91,7 +93,9 @@ export class ZenProgressTracker {
                 {this.getItemState(index) === 'active' && <div>{index + 1}</div>}
                 {this.getItemState(index) === 'completed' && <ZenIcon icon={faCheck}></ZenIcon>}
               </div>
-              <div class="label">{step.label}</div>
+              <div class="label" style={{ width: this.labelWidth }}>
+                {step.label}
+              </div>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-1242)

It was agreed by designers that labels should be 8rem. I’m now exposing a new prop labelWidth that allows you to override this default value if needed.