### PR TITLE
QUICK-FIX: Center align ZenAvatarGroup children

### DIFF
--- a/src/components/zen-avatar-group/zen-avatar-group.scss
+++ b/src/components/zen-avatar-group/zen-avatar-group.scss
@@ -1,4 +1,4 @@
 :host {
   display: flex;
-  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
#### Description
Noticed this when using it in ZenComply.

https://user-images.githubusercontent.com/9392804/110458360-f611a500-80cb-11eb-8263-c489b52706f4.mov

Simple CSS property change since `justify-content` is used for aligning items when direction is horizontal.
![Screenshot 2021-03-09 at 11 38 56](https://user-images.githubusercontent.com/9392804/110458442-0d509280-80cc-11eb-8f4f-cd483fee130f.png)

#### ChangeLOG

[Changelog](https://zen-ui.zengrc.com/?path=/docs/changelog--page)


#### Useful links
[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)

[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)

[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)
