### PR TITLE
PLAT-1491: Reflect the change of the progress tracker active index

### DIFF
--- a/src/components/zen-progress-tracker/zen-progress-tracker.tsx
+++ b/src/components/zen-progress-tracker/zen-progress-tracker.tsx
@@ -32,7 +32,7 @@ export class ZenProgressTracker {
   /** Ordered array of possible steps */
   @Prop({ reflect: true }) readonly steps: Array<StepItem> = [];
   /** Index of currently active step */
-  @Prop({ reflect: true }) readonly activeIndex: number = 0;
+  @Prop({ reflect: true, mutable: true }) activeIndex = 0;
   /** User can click step to go to step */
   @Prop({ reflect: true }) readonly clickable: StepsFilter = 'completed';
   /** Max label width */
@@ -45,7 +45,7 @@ export class ZenProgressTracker {
 
   /** User clicked a step */
   selectStep(index: number): void {
-    this.internalActiveIndex = index;
+    this.activeIndex = index;
     this.host.dispatchEvent(new window.Event('change'));
   }
 


### PR DESCRIPTION
[PLAT-1491: Progress tracker not sending information on the "change" event - JIRA](https://reciprocitylabs.atlassian.net/browse/PLAT-1491)

Hey! This is a draft because I didn't remove the "internal state" (`internalActiveIndex`) because it seems to be tied to the "items state", and when removed, only 2 out of 3 steps would trigger the event (:P)... I'm sure I was missing some context there, so I went with just mutating the prop and leave the method that watches the prop update the internal one.

By mutating the value, I didn't need to add a custom event, as the implementation can check the `target.activeIndex`.