### PR TITLE
QUICKFIX: re-enable lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
 
-# yarn lint-staged
+yarn lint-staged

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,4 @@
 {
-  "src/**/*": ["yarn lint", "yarn format"]
+  "src/**/*.{js,ts,tsx}": ["yarn lint", "yarn format"],
+  "src/**/*.{scss,md,mdx}": ["yarn format"]
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "storybook:build": "build-storybook --docs -o public --quiet",
     "storybook:theme": "start-storybook --docs -p 6006 --no-manager-cache",
     "lint:check": "eslint --ext .js,.ts,.tsx cypress/ src/",
-    "lint": "eslint --fix --ext .js,.ts,.tsx $@",
+    "lint": "eslint --fix $@",
     "lint:ci": "yarn lint:check",
     "format:check": "prettier --check cypress/ src/",
     "format": "prettier --write $@",


### PR DESCRIPTION
No Jira - Follow-up fix for #254 - We were trying to format EVERYTHING with ESLint, so I changed the config of `lint-staged` so non-t/js files are only parsed by Prettier.

@chavlji The reason #255 is failing it's because one of the files is missing Prettier formatting. You can run `yarn format src/` to fix it.