### PR TITLE
PLAT-1601: Date picker is not closed properly if user type the date

### DIFF
--- a/src/components/zen-date-picker/zen-date-picker.tsx
+++ b/src/components/zen-date-picker/zen-date-picker.tsx
@@ -96,7 +96,6 @@ export class ZenDatePicker {
     this.calendarMonth = value;
     if (this.popover && this.popover.visible && this.closeOnClick) {
       this.popover.visible = false;
-      this.input.focusInput();
     }
   }
 


### PR DESCRIPTION
- picker was reopened because of input.focus. Focusing input after click isn't needed anyway.

[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-1601)
