### PR TITLE
QUICKFIX: set the branch name for the releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -11,5 +11,6 @@
     }],
     "@semantic-release/git",
     "@semantic-release/github"
-  ]
+  ],
+  "branches": ["main"]
 }


### PR DESCRIPTION
It seems `semantic-release` work with `master` by default, so I had to configure it in order to use `main`.

(I also invited the bot to the repository, because it couldn't push the changelog)