### PR TITLE
QUICKFIX: require publish before deploy on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ workflows:
                 - main
       - deploy:
           requires:
-            - build
+            - publish
           filters:
             branches:
               only:


### PR DESCRIPTION
This is not due to an error (yet): in order to deploy the storybook, we first need the changelog to be updated, so the `deploy` step must depend on the `publish` step.

The `publish` step already depends on `build`, so the files should be there.