### PR TITLE
QUICKFIX: Enable NPM && Fix Storybook deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,11 +91,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: yarn build
+      - run: yarn stencil:build
       - persist_to_workspace:
           root: .
           paths:
-            - public
             - dist
             - loader
   publish:
@@ -104,7 +103,11 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: yarn semantic-release
+      - run: yarn semantic-release && yarn storybook:build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - public
   deploy:
     resource_class: small
     docker:

--- a/.releaserc
+++ b/.releaserc
@@ -6,7 +6,8 @@
     "@semantic-release/changelog",
     ["@amanda-mitchell/semantic-release-npm-multiple", {
       "registries": {
-        "github": {}
+        "github": {},
+        "public": {}
       }
     }],
     "@semantic-release/git",


### PR DESCRIPTION
- Now that we know that the deploy works, I re-enabled NPM deploys.
- Instead of generating the Storybook on the `build` step, since it needs to be updated after `semantic-release`, I moved it to the `publish` step and made the `build` step run only Stencil.

> Yes, the commit to enable NPM should be a `chore:`, but I want to trigger a release, that's why I used `fix:`.