### PR TITLE
QUICK: Fix Firefox storybook overlapping

### DIFF
--- a/.storybook/preview.scss
+++ b/.storybook/preview.scss
@@ -39,7 +39,6 @@ h1.sbdocs-h1 {
 }
 
 .sbdocs h3 {
-  position: static;
   font-size: 1rem;
   margin-top: 3em;
   line-height: 1.2em;
@@ -127,6 +126,8 @@ h1.sbdocs-h1 {
 // boundaries:
 .css-1wjen9k > div {
   height: auto !important;
+  transform: none;
+  -webkit-transform: none;
 }
 
 .css-25bv1u { // show code button


### PR DESCRIPTION
Fix storybook overlapping dropdown:
![](https://files.slack.com/files-pri/T09CMAAV7-F01SLNNTDST/image.png)

Also pushed commit that should be pushed in [this pr](https://github.com/reciprocity/zen-ui/pull/280):
When I set menu width to 50% the size of menu is not correct.
![113263036-9759d880-92d1-11eb-88bd-b56186d34b8a](https://user-images.githubusercontent.com/5729421/113272115-94fc7c00-92db-11eb-8b1c-e2278a4b27da.png)
