### PR TITLE
PLAT-1780: When zen-drawer is not opened on first load display is set to none

### DIFF
--- a/src/components/zen-drawer/zen-drawer.tsx
+++ b/src/components/zen-drawer/zen-drawer.tsx
@@ -49,7 +49,12 @@ export class ZenDrawer {
   }
 
   componentDidLoad(): void {
-    this.opened ? showInstantly(this.drawer) : hideInstantly(this.drawer);
+    if (this.opened) {
+      showInstantly(this.drawer);
+    } else {
+      hideInstantly(this.drawer);
+      this.host.style.display = 'none';
+    }
   }
 
   render(): HTMLElement {


### PR DESCRIPTION
[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-1780)

#### Description
As per JIRA ticket

#### ChangeLOG

[Changelog](https://zen-ui.zengrc.com/?path=/docs/changelog--page)


#### Useful links
[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)

[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)

[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)
