### PR TITLE
Re-enable React bindings deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: yarn semantic-release && yarn build
+      - run: yarn semantic-release && yarn react:publish && yarn build
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
Enabling the React bindings should be a 'chore', but we need to actually trigger a release, that's why it's a 'fix'.
