### PR TITLE
PLAT-1800: Fix types on the tests

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
 
-yarn run test:ci
+yarn run typecheck && yarn run test:ci

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // be explicit about types included
+    // to avoid clashing with Jest types
+    "types": ["cypress"]
+  },
+  "include": [
+    "../node_modules/cypress",
+    "./**/*.ts",
+    "./**/*.js"
+  ]
+}

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -6,9 +6,5 @@
     // to avoid clashing with Jest types
     "types": ["cypress"]
   },
-  "include": [
-    "../node_modules/cypress",
-    "./**/*.ts",
-    "./**/*.js"
-  ]
+  "include": ["../node_modules/cypress", "./**/*.ts", "./**/*.js"]
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "format": "prettier --write $@",
     "format:all": "yarn format src/ cypress/",
     "format:ci": "yarn format:check",
+    "typecheck": "tsc --noEmit",
     "postinstall": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -1,5 +1,8 @@
+const path = require('path');
+
 module.exports = {
   parserOptions: {
+    tsconfigRootDir: path.join(__dirname, '..'),
     project: './tsconfig.json',
   },
   parser: '@typescript-eslint/parser',

--- a/src/components/helpers/jest.ts
+++ b/src/components/helpers/jest.ts
@@ -1,7 +1,5 @@
 import { SpecPage } from '@stencil/core/testing';
 import kebabCase from 'lodash/kebabCase';
-import { jest } from '@jest/globals';
-import jestMock from 'jest-mock';
 
 type ClientPoint = { clientX: number; clientY: number };
 
@@ -47,4 +45,4 @@ export const FakeMutationObserver = <MutationObserverMock>function (this: Mutati
   return this;
 };
 
-export const createMutationObserverMock = (): jestMock.Mock<MutationObserverMock> => jest.fn(FakeMutationObserver);
+export const createMutationObserverMock = (): jest.Mock<MutationObserverMock> => jest.fn(FakeMutationObserver);

--- a/src/components/helpers/tests/animations.spec.tsx
+++ b/src/components/helpers/tests/animations.spec.tsx
@@ -1,17 +1,7 @@
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { ZenButton } from '../../zen-button/zen-button';
-
-import * as helpers from '../../helpers/helpers';
-helpers.waitNextFrame = jest.fn(() => new Promise(resolve => setTimeout(() => resolve(), 50)));
-helpers.getCssTransitionDuration = jest.fn(() => 300);
-
 import * as helpers from '../../helpers/helpers';
 import { showWithAnimation, hideWithAnimation, showInstantly, hideInstantly } from '../animations';
-
-async function simulateNextFrame(page) {
-  jest.advanceTimersByTime(50);
-  await page.waitForChanges();
-}
 
 describe('showWithAnimation()', () => {
   let page: SpecPage;
@@ -19,6 +9,14 @@ describe('showWithAnimation()', () => {
 
   beforeEach(async () => {
     jest.useFakeTimers();
+    jest
+      .spyOn(helpers, 'waitNextFrame')
+      .mockClear()
+      .mockImplementation(() => new Promise(resolve => setTimeout(resolve, 50)));
+    jest
+      .spyOn(helpers, 'getCssTransitionDuration')
+      .mockClear()
+      .mockImplementation(() => 300);
     page = await newSpecPage({
       components: [ZenButton],
       html: `<zen-button>Press</zen-button>`,
@@ -49,6 +47,10 @@ describe('showWithAnimation()', () => {
 describe('hideWithAnimation()', () => {
   let page: SpecPage;
   let button: HTMLElement;
+  const simulateNextFrame = async (page: SpecPage) => {
+    jest.advanceTimersByTime(50);
+    await page.waitForChanges();
+  };
 
   beforeEach(async () => {
     jest.useFakeTimers();

--- a/src/components/zen-animate/test/zen-animate.spec.tsx
+++ b/src/components/zen-animate/test/zen-animate.spec.tsx
@@ -1,18 +1,25 @@
 import { newSpecPage } from '@stencil/core/testing';
-import { htmlToElement } from '../../helpers/helpers';
-
-jest.useFakeTimers();
-
-const fakeSlot = htmlToElement('<div></div>')[0];
-
 import * as helpers from '../../helpers/helpers';
-helpers.getSlotElement = jest.fn(() => fakeSlot);
-helpers.getDefaultSlotContent = jest.fn(() => [fakeSlot]);
-helpers.waitNextFrame = jest.fn(() => new Promise(resolve => resolve(true)));
-
 import { ZenAnimate } from '../zen-animate';
 
 describe('zen-animate', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    const [fakeSlot] = helpers.htmlToElement('<div></div>');
+    jest
+      .spyOn(helpers, 'getSlotElement')
+      .mockClear()
+      .mockImplementation(() => (fakeSlot as unknown) as HTMLElement);
+    jest
+      .spyOn(helpers, 'getDefaultSlotContent')
+      .mockClear()
+      .mockImplementation(() => [fakeSlot]);
+    jest
+      .spyOn(helpers, 'waitNextFrame')
+      .mockClear()
+      .mockImplementation(() => new Promise(resolve => resolve(true)));
+  });
+
   it('should render', async () => {
     const page = await newSpecPage({
       components: [ZenAnimate],
@@ -62,7 +69,7 @@ describe('zen-animate', () => {
   });
 
   it('should retry to get slot if it failed first time', async () => {
-    helpers.getDefaultSlotContent = jest.fn(() => []);
+    jest.spyOn(helpers, 'getDefaultSlotContent').mockImplementation(() => []);
     const page = await newSpecPage({
       components: [ZenAnimate],
       html: `<zen-animate show="true"><h1>Slot</h1></zen-animate>`,

--- a/src/components/zen-avatar-group/test/zen-avatar-group.spec.tsx
+++ b/src/components/zen-avatar-group/test/zen-avatar-group.spec.tsx
@@ -1,5 +1,4 @@
 import { newSpecPage } from '@stencil/core/testing';
-
 import { ZenAvatarIcon } from '../../zen-avatar-icon/zen-avatar-icon';
 import { ZenAvatar } from '../../zen-avatar/zen-avatar';
 import { ZenAvatarGroup } from '../zen-avatar-group';
@@ -102,8 +101,8 @@ describe('zen-avatar-group', () => {
     page.root.users = usersColor;
     await page.waitForChanges();
     const avatar = page.root.shadowRoot.querySelector('zen-avatar');
-
-    expect(avatar.shadowRoot.querySelector('.avatar-icon').style.color).toEqual('#FFFFFF');
-    expect(avatar.shadowRoot.querySelector('.avatar-icon').style.background).toEqual('#000000');
+    const icon = avatar.shadowRoot.querySelector('.avatar-icon') as HTMLElement;
+    expect(icon.style.color).toEqual('#FFFFFF');
+    expect(icon.style.background).toEqual('#000000');
   });
 });

--- a/src/components/zen-breadcrumbs/test/zen-breadcrumbs.spec.tsx
+++ b/src/components/zen-breadcrumbs/test/zen-breadcrumbs.spec.tsx
@@ -33,7 +33,7 @@ describe('zen-breadcrumbs', () => {
   describe('insertBetween', () => {
     it.each([
       [[], []],
-      [[1], [1]],
+      [['1'], ['1']],
     ])('should not insert element into array if array has less than 2 elements (array: %s)', (arr, expected) => {
       const insertBetween = ZenBreadcrumbs.prototype.insertBetween;
       const res = insertBetween(arr, '!');
@@ -41,8 +41,8 @@ describe('zen-breadcrumbs', () => {
     });
 
     it.each([
-      [[1, 2], '&', [1, '&', 2]],
-      [[1, 2, 3], '&', [1, '&', 2, '&', 3]],
+      [['1', '2'], '&', ['1', '&', '2']],
+      [['1', '2', '3'], '&', ['1', '&', '2', '&', '3']],
     ])('should insert element between array of elements (element: %j, array: %s)', (arr, el, expected) => {
       const insertBetween = ZenBreadcrumbs.prototype.insertBetween;
       const res = insertBetween(arr, el);

--- a/src/components/zen-date-picker/tests/date-helpers.spec.ts
+++ b/src/components/zen-date-picker/tests/date-helpers.spec.ts
@@ -1,13 +1,6 @@
 import fnsFormat from 'date-fns/format';
 import { helpers } from '../date-helpers';
-
-helpers.today = jest.fn(() => new Date(1972, 2, 18));
-
 import { getDayNumbers, parseDate, getMonthName } from '../date-helpers';
-
-const dateFormat = 'MM/dd/yyyy';
-
-const format = date => fnsFormat(date, 'MM/dd/yyyy', helpers.today());
 
 describe('helpers', () => {
   it('getDayNumbers should works', () => {
@@ -25,6 +18,15 @@ describe('helpers', () => {
 });
 
 describe('parseDate', () => {
+  const format = date => fnsFormat(date, 'MM/dd/yyyy');
+  const dateFormat = 'MM/dd/yyyy';
+  beforeEach(() => {
+    jest
+      .spyOn(helpers, 'today')
+      .mockClear()
+      .mockImplementation(() => new Date(1972, 2, 18));
+  });
+
   it('should parse a valid date', () => {
     expect(format(parseDate('01/12/2021', dateFormat))).toBe('01/12/2021');
   });

--- a/src/components/zen-date-picker/tests/zen-date-picker.spec.tsx
+++ b/src/components/zen-date-picker/tests/zen-date-picker.spec.tsx
@@ -1,5 +1,5 @@
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
-import { simulateKey, simulateMouse } from '../../helpers/jest';
+import { simulateKey } from '../../helpers/jest';
 
 const popperMock = {
   destroy: jest.fn(),

--- a/src/components/zen-date-picker/tests/zen-date-picker.spec.tsx
+++ b/src/components/zen-date-picker/tests/zen-date-picker.spec.tsx
@@ -1,17 +1,7 @@
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { simulateKey } from '../../helpers/jest';
-
-const popperMock = {
-  destroy: jest.fn(),
-  state: {
-    placement: 'bottom',
-  },
-};
 import * as popper from '@popperjs/core';
-popper.createPopper = jest.fn(() => popperMock);
-
 import { helpers } from '../date-helpers';
-helpers.today = jest.fn(() => new Date(1972, 1, 18));
 
 import { ZenDatePicker } from '../zen-date-picker';
 import { ZenInput } from '../../zen-input/zen-input';
@@ -24,7 +14,26 @@ describe('zen-date-picker', () => {
   let input: HTMLZenInputElement;
   let calendar: HTMLZenPopoverElement;
 
-  const render = async (attributes: string) => {
+  beforeEach(() => {
+    jest
+      .spyOn(popper, 'createPopper')
+      .mockClear()
+      .mockImplementation(
+        () =>
+          (({
+            destroy: jest.fn(),
+            state: {
+              placement: 'bottom',
+            },
+          } as unknown) as popper.Instance),
+      );
+    jest
+      .spyOn(helpers, 'today')
+      .mockClear()
+      .mockImplementation(() => new Date(1972, 1, 18));
+  });
+
+  const render = async (attributes?: string) => {
     jest.clearAllTimers();
     jest.useFakeTimers();
     page = await newSpecPage({
@@ -39,17 +48,17 @@ describe('zen-date-picker', () => {
     calendar = datepicker.shadowRoot.querySelector('.calendar');
   };
 
-  async function focusInput() {
+  const focusInput = async () => {
     const focusin = new Event('focus', { bubbles: true, composed: true });
     datepicker.dispatchEvent(focusin);
     await page.waitForChanges();
-  }
+  };
 
-  function setInputValue(value) {
+  const setInputValue = (value: string) => {
     input.value = value;
     const event = new Event('change', { bubbles: true, composed: true });
     input.dispatchEvent(event);
-  }
+  };
 
   // ---------------------------------------------------------------------------
   it('should render with calendar hidden', async () => {
@@ -78,7 +87,7 @@ describe('zen-date-picker', () => {
 
   it('should update value on input change', async () => {
     await render();
-    setInputValue('02/02/2021', input);
+    setInputValue('02/02/2021');
     const event = new Event('change', { bubbles: true, composed: true });
     input.dispatchEvent(event);
     await page.waitForChanges();
@@ -87,7 +96,7 @@ describe('zen-date-picker', () => {
 
   it('should set value on number click', async () => {
     await render();
-    const numbers = calendar.querySelectorAll('.day-num');
+    const numbers = calendar.querySelectorAll('.day-num') as NodeListOf<HTMLElement>;
     numbers[5].click();
     await page.waitForChanges();
     expect(datepicker.value).toEqual(new Date(1972, 2 - 1, 4));
@@ -112,7 +121,7 @@ describe('zen-date-picker', () => {
   it('should change month date using arrows', async () => {
     await render();
     const date = calendar.querySelector('.date');
-    const arrows = calendar.querySelectorAll('.navigation .icon');
+    const arrows = calendar.querySelectorAll('.navigation .icon') as NodeListOf<HTMLElement>;
 
     arrows[1].click();
     await page.waitForChanges();

--- a/src/components/zen-input/test/zen-input.spec.tsx
+++ b/src/components/zen-input/test/zen-input.spec.tsx
@@ -1,13 +1,19 @@
 import { newSpecPage } from '@stencil/core/testing';
-
-let getNextFieldResult = null;
 import * as helpers from '../../helpers/helpers';
-helpers.getNextField = jest.fn(() => getNextFieldResult);
 
 import { ZenInput } from '../zen-input';
 import { ZenIcon } from '../../zen-icon/zen-icon';
 
 describe('zen-input', () => {
+  let getNextFieldResult: null | HTMLInputElement;
+  beforeEach(() => {
+    getNextFieldResult = null;
+    jest
+      .spyOn(helpers, 'getNextField')
+      .mockClear()
+      .mockImplementation(() => getNextFieldResult);
+  });
+
   it('should render with shadow dom', async () => {
     const page = await newSpecPage({
       components: [ZenInput],
@@ -172,7 +178,7 @@ describe('zen-input', () => {
       `,
     });
     const input = page.doc.querySelector('zen-input');
-    const nextInput = page.doc.querySelector('#next-input');
+    const nextInput = page.doc.querySelector<HTMLInputElement>('#next-input');
     getNextFieldResult = nextInput;
     nextInput.focus = jest.fn();
     input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));

--- a/src/components/zen-modal/test/zen-modal.spec.tsx
+++ b/src/components/zen-modal/test/zen-modal.spec.tsx
@@ -1,4 +1,4 @@
-import { newSpecPage } from '@stencil/core/testing';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { modalsService } from '../zen-modals-service';
 
 modalsService.makeTopmost = jest.fn(() => true);

--- a/src/components/zen-modal/test/zen-modals-service.spec.tsx
+++ b/src/components/zen-modal/test/zen-modals-service.spec.tsx
@@ -1,4 +1,4 @@
-import { newSpecPage } from '@stencil/core/testing';
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { modalsService } from '../zen-modals-service';
 
 import { ZenModal } from '../zen-modal';

--- a/src/components/zen-notification/test/zen-notification.spec.tsx
+++ b/src/components/zen-notification/test/zen-notification.spec.tsx
@@ -26,7 +26,7 @@ describe('zen-notification', () => {
       html: `<zen-notification heading="Test Heading" dismiss="true">Test Message</zen-notification>`,
     });
     page.rootInstance.close = jest.fn();
-    page.root.shadowRoot.querySelector('.close').click();
+    page.root.shadowRoot.querySelector<HTMLElement>('.close').click();
 
     expect(page.rootInstance.close).toHaveBeenCalled();
   });

--- a/src/components/zen-panel/test/zen-panel.spec.tsx
+++ b/src/components/zen-panel/test/zen-panel.spec.tsx
@@ -54,7 +54,7 @@ describe('zen-panel', () => {
     it('should hide with animation on click', async () => {
       await render('visible');
       expect(panel.visible).toBe(true);
-      panel.shadowRoot.querySelector('.header').click();
+      panel.shadowRoot.querySelector<HTMLElement>('.header').click();
       await page.waitForChanges();
       expect(helpers.hideWithAnimation).toHaveBeenCalled();
     });

--- a/src/components/zen-popover/test/zen-popover.spec.tsx
+++ b/src/components/zen-popover/test/zen-popover.spec.tsx
@@ -1,46 +1,52 @@
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
-
-const popperMock = {
-  destroy: jest.fn(),
-  state: {
-    placement: 'bottom',
-  },
-};
-
 import * as popper from '@popperjs/core';
-popper.createPopper = jest.fn(() => popperMock);
-
 import * as helpers from '../../helpers/helpers';
-helpers.waitNextFrame = jest.fn(() => new Promise(resolve => setTimeout(() => resolve(), 50)));
-helpers.getComposedPath = jest.fn(() => []);
-
 import { ZenPopover } from '../zen-popover';
 import { ZenButton } from '../../zen-button/zen-button';
 import { simulateMouse } from '../../helpers/jest';
 
-async function simulateNextFrame(page) {
-  jest.advanceTimersByTime(50);
-  await page.waitForChanges();
-}
-
-function isVisible(popup) {
-  return popup.getAttribute('animate') === 'in-end';
-}
-
-function isHidden(popup) {
-  return popup.getAttribute('animate') === 'out-finished';
-}
-
-// -----------------------------------------------------------------------------
 describe('zen-popover', () => {
   let page: SpecPage;
   let popover: HTMLZenPopoverElement;
   let popup: HTMLElement;
   let trigger: HTMLButtonElement;
 
-  const render = async (params?: string) => {
+  const simulateNextFrame = async page => {
+    jest.advanceTimersByTime(50);
+    await page.waitForChanges();
+  };
+
+  const isVisible = popup => popup.getAttribute('animate') === 'in-end';
+  const isHidden = popup => popup.getAttribute('animate') === 'out-finished';
+
+  // -----------------------------------------------------------------------------
+
+  beforeEach(() => {
     jest.clearAllTimers();
     jest.useFakeTimers();
+    jest
+      .spyOn(popper, 'createPopper')
+      .mockClear()
+      .mockImplementation(
+        () =>
+          (({
+            destroy: jest.fn(),
+            state: {
+              placement: 'bottom',
+            },
+          } as unknown) as popper.Instance),
+      );
+    jest
+      .spyOn(helpers, 'getComposedPath')
+      .mockClear()
+      .mockImplementation(() => []);
+    jest
+      .spyOn(helpers, 'waitNextFrame')
+      .mockClear()
+      .mockImplementation(() => new Promise(resolve => setTimeout(resolve, 50)));
+  });
+
+  const render = async (params?: string) => {
     page = await newSpecPage({
       components: [ZenPopover, ZenButton],
       html: /*html*/ `
@@ -54,7 +60,7 @@ describe('zen-popover', () => {
     });
     await page.waitForChanges();
     popover = page.doc.querySelector('zen-popover') as HTMLZenPopoverElement;
-    trigger = page.doc.querySelector('zen-button');
+    trigger = page.doc.querySelector<HTMLButtonElement>('zen-button');
     popup = popover.shadowRoot.querySelector('.popup');
   };
 
@@ -116,7 +122,7 @@ describe('zen-popover', () => {
     await simulateNextFrame(page); // wait to create popper
     jest.runAllTimers(); // mouse down listener is added in timeout
 
-    simulateMouse('mousedown', global.document);
+    simulateMouse('mousedown', (global.document as unknown) as Element);
     await simulateNextFrame(page); // clickOut has waitNextFrame
 
     expect(popover.visible).toBeFalsy();
@@ -142,7 +148,7 @@ describe('zen-popover', () => {
     await simulateNextFrame(page); // wait to create popper
     jest.runAllTimers(); // mouse down listener is added in timeout
 
-    simulateMouse('mousedown', global.document);
+    simulateMouse('mousedown', (global.document as unknown) as Element);
     await simulateNextFrame(page); // clickOut has waitNextFrame
 
     expect(popover.visible).toBeFalsy();
@@ -158,7 +164,7 @@ describe('zen-popover', () => {
     await simulateNextFrame(page); // wait to create popper
     jest.runAllTimers(); // mouse down listener is added in timeout
 
-    simulateMouse('mousedown', global.document);
+    simulateMouse('mousedown', (global.document as unknown) as Element);
     await simulateNextFrame(page); // clickOut has waitNextFrame
 
     expect(popover.visible).toBeTruthy();
@@ -205,7 +211,7 @@ describe('zen-popover', () => {
     await simulateNextFrame(page); // wait to create popper
     jest.runAllTimers(); // mouse down listener is added in timeout
 
-    simulateMouse('mousedown', global.document);
+    simulateMouse('mousedown', (global.document as unknown) as Element);
     await simulateNextFrame(page); // clickOut has waitNextFrame
 
     expect(popover.visible).toBeFalsy();

--- a/src/components/zen-popover/test/zen-popover.spec.tsx
+++ b/src/components/zen-popover/test/zen-popover.spec.tsx
@@ -10,6 +10,7 @@ describe('zen-popover', () => {
   let popover: HTMLZenPopoverElement;
   let popup: HTMLElement;
   let trigger: HTMLButtonElement;
+  const documentElement = (global.document as unknown) as Element;
 
   const simulateNextFrame = async page => {
     jest.advanceTimersByTime(50);
@@ -122,7 +123,7 @@ describe('zen-popover', () => {
     await simulateNextFrame(page); // wait to create popper
     jest.runAllTimers(); // mouse down listener is added in timeout
 
-    simulateMouse('mousedown', (global.document as unknown) as Element);
+    simulateMouse('mousedown', documentElement);
     await simulateNextFrame(page); // clickOut has waitNextFrame
 
     expect(popover.visible).toBeFalsy();
@@ -148,7 +149,7 @@ describe('zen-popover', () => {
     await simulateNextFrame(page); // wait to create popper
     jest.runAllTimers(); // mouse down listener is added in timeout
 
-    simulateMouse('mousedown', (global.document as unknown) as Element);
+    simulateMouse('mousedown', documentElement);
     await simulateNextFrame(page); // clickOut has waitNextFrame
 
     expect(popover.visible).toBeFalsy();
@@ -164,7 +165,7 @@ describe('zen-popover', () => {
     await simulateNextFrame(page); // wait to create popper
     jest.runAllTimers(); // mouse down listener is added in timeout
 
-    simulateMouse('mousedown', (global.document as unknown) as Element);
+    simulateMouse('mousedown', documentElement);
     await simulateNextFrame(page); // clickOut has waitNextFrame
 
     expect(popover.visible).toBeTruthy();
@@ -211,7 +212,7 @@ describe('zen-popover', () => {
     await simulateNextFrame(page); // wait to create popper
     jest.runAllTimers(); // mouse down listener is added in timeout
 
-    simulateMouse('mousedown', (global.document as unknown) as Element);
+    simulateMouse('mousedown', documentElement);
     await simulateNextFrame(page); // clickOut has waitNextFrame
 
     expect(popover.visible).toBeFalsy();

--- a/src/components/zen-table/test/zen-table.spec.tsx
+++ b/src/components/zen-table/test/zen-table.spec.tsx
@@ -4,8 +4,6 @@ const originalMutationObserver = global.MutationObserver;
 import { newSpecPage } from '@stencil/core/testing';
 import { ZenTable } from '../zen-table';
 
-// let consoleErrorMock: jest.MockedFunction<typeof console.error>;
-
 describe('zen-table', () => {
   let mutationObserverMock: jest.Mock<MutationObserverMock>;
 

--- a/src/components/zen-table/test/zen-table.spec.tsx
+++ b/src/components/zen-table/test/zen-table.spec.tsx
@@ -1,21 +1,13 @@
-import { expect, jest, beforeAll, afterAll } from '@jest/globals';
-import jestMock from 'jest-mock';
 import { createMutationObserverMock, MutationObserverMock } from '../../helpers/jest';
 const originalMutationObserver = global.MutationObserver;
 
 import { newSpecPage } from '@stencil/core/testing';
 import { ZenTable } from '../zen-table';
 
-let consoleErrorMock;
+// let consoleErrorMock: jest.MockedFunction<typeof console.error>;
 
 describe('zen-table', () => {
-  let mutationObserverMock: jestMock.Mock<MutationObserverMock>;
-
-  beforeAll(() => {
-    consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {
-      // nothing
-    });
-  });
+  let mutationObserverMock: jest.Mock<MutationObserverMock>;
 
   beforeEach(() => {
     mutationObserverMock = createMutationObserverMock();
@@ -25,11 +17,6 @@ describe('zen-table', () => {
   afterEach(() => {
     global.MutationObserver = originalMutationObserver;
     mutationObserverMock.mockClear();
-    consoleErrorMock.mockClear();
-  });
-
-  afterAll(() => {
-    consoleErrorMock.mockRestore();
   });
 
   it('should render', async () => {
@@ -49,15 +36,18 @@ describe('zen-table', () => {
 
     page.root.remove();
     await page.waitForChanges();
-    const [observerInstance] = global.MutationObserver.mock.instances;
+    const [observerInstance] = mutationObserverMock.mock.instances;
     expect(observerInstance.disconnect).toHaveBeenCalledTimes(1);
   });
 
   it('should throw error if columns not defined', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {
+      // Do nothig, because we expect the error.
+    });
     await newSpecPage({
       components: [ZenTable],
       html: `<zen-table>Content</zen-table>`,
     });
-    expect(global.console.error).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/zen-tooltip/test/zen-tooltip.spec.tsx
+++ b/src/components/zen-tooltip/test/zen-tooltip.spec.tsx
@@ -1,18 +1,24 @@
 import { newSpecPage } from '@stencil/core/testing';
-
-const popperMock = {
-  destroy: jest.fn(),
-  state: {
-    placement: 'bottom',
-  },
-};
 import * as popper from '@popperjs/core';
-popper.createPopper = jest.fn(() => popperMock);
-
 import { ZenTooltip } from '../zen-tooltip';
 import { ZenPopover } from '../../zen-popover/zen-popover';
 
 describe('zen-tooltip', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(popper, 'createPopper')
+      .mockClear()
+      .mockImplementation(
+        () =>
+          (({
+            destroy: jest.fn(),
+            state: {
+              placement: 'bottom',
+            },
+          } as unknown) as popper.Instance),
+      );
+  });
+
   it('should correctly apply correct color to each variant', async () => {
     const page = await newSpecPage({
       components: [ZenTooltip, ZenPopover],
@@ -27,7 +33,9 @@ describe('zen-tooltip', () => {
     tooltip.variant = 'error';
     await page.waitForChanges();
     expect(popover.backgroundColor).toEqual('#c22f3d');
-
+    // This is an invalid case; we need to review it, because there's no "empty variant".
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     tooltip.variant = '';
     await page.waitForChanges();
     expect(popover.backgroundColor).toEqual('');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["cypress", "node"]
+    "types": ["jest", "node"]
   },
   "include": [
     "src", "types/jsx.d.ts", "./typings.d.ts", "./stencil.config.ts", "cypress"


### PR DESCRIPTION
[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-1800)

#### Description

- The main `tsconfig` now uses the jest types, and on the `cypress` directory there's a new `tsconfig` that extends the one on the root, with the types for cypress.
- I fixed all the type errors and most of the mock implementations on the unit tests; the reason I also changed the mocks it's because most of the type issues were related to that.
- I added a new `typecheck` script to the `package.json` and hooked it on the `pre-push`, like `mf-execution`.
- Yes, the commits are really small in some cases, and it's possible that I could've used one commit for each type of change, but I actually did the changes one component at a time, based on the `tsc` report. I also considered that it could be beneficial to have these small commits as references.

To be clear: I fixed the issues, but there are some cases (like the dropdown) where I know there's a mix of types (`HTMLElement` vs `Element`) and I had to add "unknown conversions" to get it to work; so the TypeScript part, may need a good review in the future.

Regarding the "Jest part", I ended up using spies instead of direct mocks because some cases used some mocked helpers and some real functions, and spies work best in those cases. Normally, you would "mock the entire dependency" and "prepare the implementation".

I also converted some functions to arrow functions; not because it's my preference (although it is :P), but because we had some arrows and some regular functions, and I like to be consistent (when possible).
