### PR TITLE
QUICK: Bugfix - Date picker - empty if formattedDate === today

### DIFF
--- a/src/components/zen-date-picker/zen-date-picker.tsx
+++ b/src/components/zen-date-picker/zen-date-picker.tsx
@@ -218,9 +218,8 @@ export class ZenDatePicker {
   componentDidLoad(): void {
     if (this.formattedDate !== 'null' && this.formattedDate !== null) {
       this.formattedDateChanged(this.formattedDate);
-    } else {
-      this.dateChanged(this.value); // set today date
     }
+    this.dateChanged(this.value); // set today date
   }
 
   render(): HTMLElement {


### PR DESCRIPTION
Bug:
Zen-date-picker: If attr `formatted-date` is set to same date as today, value isn't initialized and calendar is empty:
<img width="1680" alt="Screen Shot 2021-04-20 at 10 39 29" src="https://user-images.githubusercontent.com/5729421/115416743-541bc700-a1f8-11eb-97a5-f7827261e592.png">
