### PR TITLE
QUICK-FIX(zen-tabs): prevent selected tab jumping

### DIFF
--- a/src/components/zen-tab/zen-tab.scss
+++ b/src/components/zen-tab/zen-tab.scss
@@ -9,6 +9,7 @@
   border-bottom: 4px solid transparent;
   color: $color-gray-400;
   font-size: $text-md;
+  letter-spacing: 0.5px;
 
   ::slotted(*) {
     color: $color-gray-400;
@@ -22,5 +23,5 @@
 :host([selected]) {
   border-bottom: 4px solid $color-blue-700;
   color: $color-gray-800;
-  font-weight: bold;
+  text-shadow: 1px 0 $color-gray-800;
 }


### PR DESCRIPTION
Eliminate ugly tabs jumping when selecting a tab. Uses `text-shadow` instead `font-weight`.
Difference is imo very hard to notice even if you compare it side by side:
![Screenshot 2021-04-22 at 11 20 28](https://user-images.githubusercontent.com/5729421/115690197-18e6d880-a35d-11eb-8b2e-bfa31d59fd7e.jpg)
