### PR TITLE
PLAT-1978: Change events name to to zen prefix ones

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -699,6 +699,10 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
+          * Method triggers a custom event "zenChange"
+         */
+        "dispatchChangeEvent": () => Promise<void>;
+        /**
           * Group id to which this radio belongs
          */
         "group": string;
@@ -1771,6 +1775,10 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         /**
+          * Checkbox change event
+         */
+        "onZenChange"?: (event: CustomEvent<void>) => void;
+        /**
           * Shows a red asterisk after label.
          */
         "required"?: boolean;
@@ -1804,6 +1812,10 @@ declare namespace LocalJSX {
           * Shows invalid styles
          */
         "invalid"?: boolean;
+        /**
+          * Date picker change event
+         */
+        "onZenChange"?: (event: CustomEvent<void>) => void;
         /**
           * Placeholder
          */
@@ -1887,6 +1899,10 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         /**
+          * Dropdown change event
+         */
+        "onZenChange"?: (event: CustomEvent<void>) => void;
+        /**
           * Text in field if nothing selected
          */
         "placeholder"?: string;
@@ -1954,6 +1970,10 @@ declare namespace LocalJSX {
           * Name of element, can be used as reference for form data
          */
         "name"?: string;
+        /**
+          * Input change event
+         */
+        "onZenChange"?: (event: CustomEvent<void>) => void;
         /**
           * Placeholder of the input.
          */
@@ -2199,6 +2219,10 @@ declare namespace LocalJSX {
          */
         "labelWidth"?: string;
         /**
+          * Progress tracker change event
+         */
+        "onZenChange"?: (event: CustomEvent<void>) => void;
+        /**
           * Ordered array of possible steps
          */
         "steps"?: Array<StepItem>;
@@ -2220,6 +2244,10 @@ declare namespace LocalJSX {
           * Name of element, can be used as reference for form data
          */
         "name"?: string;
+        /**
+          * Radio change event
+         */
+        "onZenChange"?: (event: CustomEvent<void>) => void;
         /**
           * Shows a red asterisk after label
          */
@@ -2555,6 +2583,10 @@ declare namespace LocalJSX {
     }
     interface ZenTabs {
         /**
+          * Tabs change event
+         */
+        "onZenChange"?: (event: CustomEvent<void>) => void;
+        /**
           * Index of currently selected tab.
          */
         "value"?: number;
@@ -2639,6 +2671,10 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         /**
+          * Textarea change event
+         */
+        "onZenChange"?: (event: CustomEvent<void>) => void;
+        /**
           * Placeholder of the textarea.
          */
         "placeholder"?: string;
@@ -2672,6 +2708,10 @@ declare namespace LocalJSX {
           * Name of element, can be used as reference for form data
          */
         "name"?: string;
+        /**
+          * Toggle change event
+         */
+        "onZenChange"?: (event: CustomEvent<void>) => void;
     }
     interface ZenTooltip {
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2301,11 +2301,11 @@ declare namespace LocalJSX {
         /**
           * Inner sidebar hide button clicked
          */
-        "onCollapse"?: (event: CustomEvent<void>) => void;
+        "onZenCollapse"?: (event: CustomEvent<void>) => void;
         /**
           * On sidebar collapse/expand
          */
-        "onToggle"?: (event: CustomEvent<{ expanded: boolean }>) => void;
+        "onZenToggle"?: (event: CustomEvent<{ expanded: boolean }>) => void;
         /**
           * <Description generated in helper file>
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -51,7 +51,7 @@ export namespace Components {
         /**
           * What framework is initally selected
          */
-        "selectedFramework": string;
+        "selectedFramework": number;
         /**
           * What framework is initally selected
          */
@@ -1573,7 +1573,7 @@ declare namespace LocalJSX {
         /**
           * What framework is initally selected
          */
-        "selectedFramework"?: string;
+        "selectedFramework"?: number;
         /**
           * What framework is initally selected
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2363,7 +2363,7 @@ declare namespace LocalJSX {
         /**
           * Item was selected
          */
-        "onSubitemSelect"?: (event: CustomEvent<void>) => void;
+        "onZenSubitemSelect"?: (event: CustomEvent<void>) => void;
         /**
           * Render item as selected
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2057,11 +2057,11 @@ declare namespace LocalJSX {
         /**
           * Top-right X button or default Cancel button clicked
          */
-        "onCancel"?: (event: CustomEvent<void>) => void;
+        "onZenCancel"?: (event: CustomEvent<void>) => void;
         /**
           * Default Ok button clicked (irrelevant if slot `buttons` passed)
          */
-        "onOk"?: (event: CustomEvent<void>) => void;
+        "onZenOk"?: (event: CustomEvent<void>) => void;
         /**
           * Set `true` to show and `false` to hide modal
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1813,9 +1813,17 @@ declare namespace LocalJSX {
          */
         "invalid"?: boolean;
         /**
+          * Date picker blur event
+         */
+        "onZenBlur"?: (event: CustomEvent<void>) => void;
+        /**
           * Date picker change event
          */
         "onZenChange"?: (event: CustomEvent<void>) => void;
+        /**
+          * Date picker focus event
+         */
+        "onZenFocus"?: (event: CustomEvent<void>) => void;
         /**
           * Placeholder
          */
@@ -1835,7 +1843,7 @@ declare namespace LocalJSX {
         /**
           * Inner drawer hide button clicked
          */
-        "onClose"?: (event: CustomEvent<void>) => void;
+        "onZenClose"?: (event: CustomEvent<void>) => void;
         /**
           * Is drawer visible
          */
@@ -1899,9 +1907,17 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         /**
+          * Dropdown blur event
+         */
+        "onZenBlur"?: (event: CustomEvent<void>) => void;
+        /**
           * Dropdown change event
          */
         "onZenChange"?: (event: CustomEvent<void>) => void;
+        /**
+          * Dropdown focus event
+         */
+        "onZenFocus"?: (event: CustomEvent<void>) => void;
         /**
           * Text in field if nothing selected
          */
@@ -1971,9 +1987,21 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         /**
+          * Input blur event
+         */
+        "onZenBlur"?: (event: CustomEvent<void>) => void;
+        /**
           * Input change event
          */
         "onZenChange"?: (event: CustomEvent<void>) => void;
+        /**
+          * Input focus event
+         */
+        "onZenFocus"?: (event: CustomEvent<void>) => void;
+        /**
+          * Input event
+         */
+        "onZenInput"?: (event: CustomEvent<void>) => void;
         /**
           * Placeholder of the input.
          */
@@ -2109,11 +2137,11 @@ declare namespace LocalJSX {
         /**
           * Panel closed
          */
-        "onClose"?: (event: CustomEvent<void>) => void;
+        "onZenClose"?: (event: CustomEvent<void>) => void;
         /**
           * Panel opened
          */
-        "onOpen"?: (event: CustomEvent<void>) => void;
+        "onZenOpen"?: (event: CustomEvent<void>) => void;
         /**
           * <Description generated in helper file>
          */
@@ -2165,9 +2193,9 @@ declare namespace LocalJSX {
          */
         "offset"?: Offsets;
         /**
-          * Visibility changed
+          * Zen popover visibility change event
          */
-        "onVisibleChange"?: (event: CustomEvent<void>) => void;
+        "onZenVisibleChange"?: (event: CustomEvent<void>) => void;
         /**
           * <Description generated in helper file>
          */
@@ -2473,7 +2501,7 @@ declare namespace LocalJSX {
         /**
           * Tab selected event
          */
-        "onTabSelect"?: (event: CustomEvent<void>) => void;
+        "onZenSelect"?: (event: CustomEvent<void>) => void;
         /**
           * Set tab selected
          */
@@ -2671,9 +2699,21 @@ declare namespace LocalJSX {
          */
         "name"?: string;
         /**
+          * Textarea blur event
+         */
+        "onZenBlur"?: (event: CustomEvent<void>) => void;
+        /**
           * Textarea change event
          */
         "onZenChange"?: (event: CustomEvent<void>) => void;
+        /**
+          * Textarea focus event
+         */
+        "onZenFocus"?: (event: CustomEvent<void>) => void;
+        /**
+          * Textarea event
+         */
+        "onZenInput"?: (event: CustomEvent<void>) => void;
         /**
           * Placeholder of the textarea.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2594,6 +2594,7 @@ declare namespace LocalJSX {
         "header"?: boolean;
         /**
           * Row selected
+          * @todo Is this really needed?
          */
         "onRowSelectChanged"?: (event: CustomEvent<boolean>) => void;
         /**

--- a/src/components/zen-checkbox/zen-checkbox.tsx
+++ b/src/components/zen-checkbox/zen-checkbox.tsx
@@ -1,7 +1,6 @@
-import { Component, Host, h, Prop, Watch, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Watch, Element, Event, EventEmitter } from '@stencil/core';
 
 /**
- * @event change | Called whenever checkbox value changes
  * @event click | Called when checkbox value changes due to user action
  */
 
@@ -31,9 +30,12 @@ export class ZenCheckbox {
   /** Shows the checkbox in indeterminate state */
   @Prop({ mutable: true }) indeterminate = false;
 
+  /** Checkbox change event */
+  @Event() zenChange: EventEmitter<void>;
+
   @Watch('checked')
   checkedChanged(): void {
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   }
 
   componentDidLoad(): void {

--- a/src/components/zen-date-picker/tests/zen-date-picker.spec.tsx
+++ b/src/components/zen-date-picker/tests/zen-date-picker.spec.tsx
@@ -56,7 +56,7 @@ describe('zen-date-picker', () => {
 
   const setInputValue = (value: string) => {
     input.value = value;
-    const event = new Event('change', { bubbles: true, composed: true });
+    const event = new Event('zenChange', { bubbles: true, composed: true });
     input.dispatchEvent(event);
   };
 

--- a/src/components/zen-date-picker/zen-date-picker.tsx
+++ b/src/components/zen-date-picker/zen-date-picker.tsx
@@ -27,8 +27,6 @@ enum Navigate {
 }
 
 /**
- * @event focus | Focused
- * @event blur | Focus lost
  * @event click | Clicked
  */
 
@@ -85,6 +83,12 @@ export class ZenDatePicker {
 
   /** Date picker change event */
   @Event() zenChange: EventEmitter<void>;
+
+  /**  Date picker focus event */
+  @Event() zenFocus: EventEmitter<void>;
+
+  /**  Date picker blur event */
+  @Event() zenBlur: EventEmitter<void>;
 
   @Watch('formattedDate')
   async formattedDateChanged(formatted: string): Promise<void> {
@@ -161,10 +165,12 @@ export class ZenDatePicker {
 
   onBlur(): void {
     this.popover.toggle(false);
+    this.zenBlur.emit();
   }
 
   onFocus(): void {
     this.popover.toggle(true);
+    this.zenFocus.emit();
   }
 
   navigate(type: Navigate): void {

--- a/src/components/zen-date-picker/zen-date-picker.tsx
+++ b/src/components/zen-date-picker/zen-date-picker.tsx
@@ -210,6 +210,7 @@ export class ZenDatePicker {
   }
 
   onInputChange(event: Event): void {
+    event.stopPropagation();
     const input = event.target as HTMLInputElement;
     if (!input.value && this.allowEmpty) {
       this.clearDate();
@@ -225,6 +226,10 @@ export class ZenDatePicker {
       // revert to old date:
       this.dateChanged(this.value);
     }
+  }
+
+  stopEventPropagation(event: Event): void {
+    event.stopPropagation();
   }
 
   onOpenToggle(popup: HTMLZenPopoverElement): void {
@@ -271,7 +276,9 @@ export class ZenDatePicker {
           value={this.formattedDate}
           has-focus={this.opened}
           clear-button={this.allowEmpty ? 'true' : 'false'}
-          onChange={e => this.onInputChange(e)}
+          onZenChange={e => this.onInputChange(e)}
+          onZenFocus={this.stopEventPropagation}
+          onZenBlur={this.stopEventPropagation}
           size={this.size}
         >
           <ZenIcon
@@ -289,7 +296,7 @@ export class ZenDatePicker {
           interactive
           position="bottom-start"
           close-on-target-click="false"
-          onVisibleChange={e => this.onOpenToggle(e.target)}
+          onZenVisibleChange={e => this.onOpenToggle(e.target)}
         >
           <ZenSpace class="navigation" spacing="sm" padding="sm lg" horizontal-align="center" vertical-align="stretch">
             <ZenIcon

--- a/src/components/zen-date-picker/zen-date-picker.tsx
+++ b/src/components/zen-date-picker/zen-date-picker.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Watch, State, Element, Listen, Method } from '@stencil/core';
+import { Component, Host, h, Prop, Watch, State, Element, Listen, Method, Event, EventEmitter } from '@stencil/core';
 import { getDayNumbers, helpers, getMonthName, parseDate } from './date-helpers';
 import getYear from 'date-fns/getYear';
 import addMonths from 'date-fns/addMonths';
@@ -27,7 +27,6 @@ enum Navigate {
 }
 
 /**
- * @event change | Called on date change
  * @event focus | Focused
  * @event blur | Focus lost
  * @event click | Clicked
@@ -84,6 +83,9 @@ export class ZenDatePicker {
   /** Size variant */
   @Prop({ reflect: true }) readonly size: InputSize = 'md';
 
+  /** Date picker change event */
+  @Event() zenChange: EventEmitter<void>;
+
   @Watch('formattedDate')
   async formattedDateChanged(formatted: string): Promise<void> {
     const parsedDate = parseDate(formatted, this.format);
@@ -97,7 +99,7 @@ export class ZenDatePicker {
     } else {
       this.value = helpers.today();
     }
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   }
 
   @Watch('value')
@@ -146,7 +148,7 @@ export class ZenDatePicker {
   @Method()
   async clearDate(): Promise<void> {
     this.value = new Date(NaN);
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   }
 
   ensureValidFormatString(fallback = 'MM/dd/yyyy'): void {
@@ -185,7 +187,7 @@ export class ZenDatePicker {
   selectDay(day: number): void {
     if (!day) return;
     this.value = setDate(this.calendarMonth, day);
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   }
 
   isSelected(day: number): boolean {
@@ -212,7 +214,7 @@ export class ZenDatePicker {
 
     if (isValid(date)) {
       this.value = date;
-      this.host.dispatchEvent(new window.Event('change'));
+      this.zenChange.emit();
     } else {
       // revert to old date:
       this.dateChanged(this.value);

--- a/src/components/zen-drawer/test/zen-drawer.spec.tsx
+++ b/src/components/zen-drawer/test/zen-drawer.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { ZenDrawer } from '../zen-drawer';
+import { simulateMouse } from '../../helpers/jest';
 
 describe('zen-drawer', () => {
   it('should render with shadow dom', async () => {
@@ -8,5 +9,33 @@ describe('zen-drawer', () => {
       html: `<zen-drawer></zen-drawer>`,
     });
     expect(page.root.shadowRoot).toBeTruthy();
+  });
+
+  it('should open the drawer', async () => {
+    const page = await newSpecPage({
+      components: [ZenDrawer],
+      html: `<zen-drawer></zen-drawer>`,
+    });
+    const drawer = page.root as HTMLZenDrawerElement;
+    drawer.opened = true;
+    await page.waitForChanges();
+    expect(drawer.hasAttribute('opened')).toBeTruthy();
+  });
+
+  it('should close the drawer', async () => {
+    const page = await newSpecPage({
+      components: [ZenDrawer],
+      html: `<zen-drawer opened><zen-text>Drawer</zen-text></zen-drawer>`,
+    });
+    const drawer = page.root as HTMLZenDrawerElement;
+    drawer.opened = false;
+    await page.waitForChanges();
+    expect(drawer.hasAttribute('opened')).toEqual(false);
+
+    drawer.opened = true;
+    const closeBtn = drawer.shadowRoot.querySelector('.close-btn');
+
+    simulateMouse('click', closeBtn);
+    expect(drawer.hasAttribute('opened')).toEqual(false);
   });
 });

--- a/src/components/zen-drawer/zen-drawer.tsx
+++ b/src/components/zen-drawer/zen-drawer.tsx
@@ -32,7 +32,7 @@ export class ZenDrawer {
   @Prop() readonly paddingLeft: Spacing = null;
 
   /** Inner drawer hide button clicked */
-  @Event() close: EventEmitter<void>;
+  @Event() zenClose: EventEmitter<void>;
 
   @Watch('opened')
   async openedChanged(): Promise<void> {
@@ -45,7 +45,7 @@ export class ZenDrawer {
   }
 
   onCloseClicked(): void {
-    this.close.emit();
+    this.zenClose.emit();
   }
 
   componentDidLoad(): void {

--- a/src/components/zen-drawer/zen-drawer.tsx
+++ b/src/components/zen-drawer/zen-drawer.tsx
@@ -15,7 +15,7 @@ export class ZenDrawer {
   @Element() host: HTMLZenDrawerElement;
 
   /** Is drawer visible */
-  @Prop({ reflect: true }) readonly opened: boolean = false;
+  @Prop({ reflect: true, mutable: true }) opened = false;
 
   /** Position */
   @Prop({ reflect: true }) readonly position: Position = 'right';
@@ -45,6 +45,7 @@ export class ZenDrawer {
   }
 
   onCloseClicked(): void {
+    this.opened = !this.opened;
     this.zenClose.emit();
   }
 

--- a/src/components/zen-dropdown/zen-dropdown.stories.mdx
+++ b/src/components/zen-dropdown/zen-dropdown.stories.mdx
@@ -150,8 +150,8 @@ export const InvitePeople = () => {
       style="width: auto"
       menu-width="220px"
       field-align="right"
-      @focus="${onDropdownFocus}"
-      @blur="${onDropdownBlur}"
+      @zenFocus="${onDropdownFocus}"
+      @zenBlur="${onDropdownBlur}"
     >
       <sb-zen-option value="admin">ZenGRC Administrator</sb-zen-option>
       <sb-zen-option value="manager">Manager</sb-zen-option>

--- a/src/components/zen-dropdown/zen-dropdown.tsx
+++ b/src/components/zen-dropdown/zen-dropdown.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, State, Listen, Watch, Element, Method } from '@stencil/core';
+import { Component, Host, h, Prop, State, Listen, Watch, Element, Method, Event, EventEmitter } from '@stencil/core';
 import { getDefaultSlotContent, applyPrefix, scrollIntoView } from '../helpers/helpers';
 import { faChevronDown } from '@fortawesome/pro-light-svg-icons';
 import { OptionValue } from '../zen-menu-item/zen-option';
@@ -11,7 +11,6 @@ export interface OptionItem {
 /**
  * @slot [default] - Content for dropdown menu
  * @slot placeholder - Slot visible in field when nothing is selected
- * @event change | Called on any selection change
  * @event focus | Focused
  * @event blur | Focus lost
  */
@@ -60,6 +59,9 @@ export class ZenDropdown {
 
   /** Shows invalid styles. */
   @Prop() readonly invalid: boolean = false;
+
+  /** Dropdown change event */
+  @Event() zenChange: EventEmitter<void>;
 
   /** Close an opened dropdown menu */
   @Method()
@@ -204,7 +206,7 @@ export class ZenDropdown {
     if (this.closeOnSelect) {
       this.popover.visible = false;
     }
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   }
 
   async setFocusedOption(option?: HTMLZenOptionElement): Promise<void> {

--- a/src/components/zen-dropdown/zen-dropdown.tsx
+++ b/src/components/zen-dropdown/zen-dropdown.tsx
@@ -11,8 +11,6 @@ export interface OptionItem {
 /**
  * @slot [default] - Content for dropdown menu
  * @slot placeholder - Slot visible in field when nothing is selected
- * @event focus | Focused
- * @event blur | Focus lost
  */
 
 @Component({
@@ -62,6 +60,12 @@ export class ZenDropdown {
 
   /** Dropdown change event */
   @Event() zenChange: EventEmitter<void>;
+
+  /**  Dropdown focus event */
+  @Event() zenFocus: EventEmitter<void>;
+
+  /**  Dropdown blur event */
+  @Event() zenBlur: EventEmitter<void>;
 
   /** Close an opened dropdown menu */
   @Method()
@@ -132,10 +136,12 @@ export class ZenDropdown {
 
   onBlur(): void {
     this.popover.toggle(false);
+    this.zenBlur.emit();
   }
 
   onFocus(): void {
     this.popover.toggle(true);
+    this.zenFocus.emit();
   }
 
   cloneSelectedToField(): void {
@@ -307,7 +313,7 @@ export class ZenDropdown {
           ref={el => (this.popover = el)}
           interactive
           position={align}
-          onVisibleChange={() => this.onOpenToggle()}
+          onZenVisibleChange={() => this.onOpenToggle()}
           style={{ width: this.menuWidth, 'max-height': this.menuHeight }}
           offset={offset}
         >

--- a/src/components/zen-input/zen-input.tsx
+++ b/src/components/zen-input/zen-input.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Element, Listen, State, Method, Watch } from '@stencil/core';
+import { Component, Host, h, Prop, Element, Listen, State, Method, Watch, Event, EventEmitter } from '@stencil/core';
 import { getNextField } from '../helpers/helpers';
 import { faTimes } from '@fortawesome/pro-regular-svg-icons';
 import { applyPrefix } from '../helpers/helpers';
@@ -7,7 +7,6 @@ import { InputSize } from '../helpers/types';
 /**
  * @slot leadingSlot - Slot placed at the left
  * @slot trailingSlot - Slot placed at the right
- * @event change | Content change applied
  * @event input | Content changed
  * @event focus | Focused
  * @event blur | Focus lost
@@ -53,6 +52,9 @@ export class ZenInput {
   /** Size variant */
   @Prop({ reflect: true }) readonly size: InputSize = 'md';
 
+  /** Input change event */
+  @Event() zenChange: EventEmitter<void>;
+
   @Listen('keydown')
   handleKeyDown(ev: KeyboardEvent): void {
     if (ev.key === 'Enter' && this.enterToTab) {
@@ -87,7 +89,7 @@ export class ZenInput {
       this.value = input.value || '';
     }
     // change event should be forwarded, because it's not composed:
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   };
 
   private onBlur = () => {
@@ -105,7 +107,7 @@ export class ZenInput {
   private onClearClick(event: Event): void {
     this.value = '';
     this.input.value = '';
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
     event.stopPropagation();
     event.preventDefault();
   }

--- a/src/components/zen-input/zen-input.tsx
+++ b/src/components/zen-input/zen-input.tsx
@@ -7,9 +7,6 @@ import { InputSize } from '../helpers/types';
 /**
  * @slot leadingSlot - Slot placed at the left
  * @slot trailingSlot - Slot placed at the right
- * @event input | Content changed
- * @event focus | Focused
- * @event blur | Focus lost
  */
 @Component({
   tag: 'zen-input',
@@ -55,6 +52,15 @@ export class ZenInput {
   /** Input change event */
   @Event() zenChange: EventEmitter<void>;
 
+  /** Input event */
+  @Event() zenInput: EventEmitter<void>;
+
+  /** Input focus event */
+  @Event() zenFocus: EventEmitter<void>;
+
+  /** Input blur event */
+  @Event() zenBlur: EventEmitter<void>;
+
   @Listen('keydown')
   handleKeyDown(ev: KeyboardEvent): void {
     if (ev.key === 'Enter' && this.enterToTab) {
@@ -81,6 +87,7 @@ export class ZenInput {
       this.value = input.value || '';
       this.isEmpty = !input.value;
     }
+    this.zenInput.emit();
   };
 
   private onChange = (ev: Event) => {
@@ -94,10 +101,12 @@ export class ZenInput {
 
   private onBlur = () => {
     this.inputFocused = false;
+    this.zenBlur.emit();
   };
 
   private onFocus = () => {
     this.inputFocused = true;
+    this.zenFocus.emit();
   };
 
   private getValue(): string {

--- a/src/components/zen-modal/test/zen-modal.spec.tsx
+++ b/src/components/zen-modal/test/zen-modal.spec.tsx
@@ -29,15 +29,15 @@ describe('zen-modal', () => {
   });
 
   it('should emit cancel event', async () => {
-    await testClickEvent(page, '.x-button', 'cancel');
+    await testClickEvent(page, '.x-button', 'zenCancel');
   });
 
   it('should emit cancel event with default cancel button', async () => {
-    await testClickEvent(page, 'slot[name="footer"] .btn-cancel', 'cancel');
+    await testClickEvent(page, 'slot[name="footer"] .btn-cancel', 'zenCancel');
   });
 
   it('should emit ok event with default ok button', async () => {
-    await testClickEvent(page, 'slot[name="footer"] .btn-ok', 'ok');
+    await testClickEvent(page, 'slot[name="footer"] .btn-ok', 'zenOk');
   });
 
   it('should call makeTopmost on show', async () => {

--- a/src/components/zen-modal/zen-modal.stories.mdx
+++ b/src/components/zen-modal/zen-modal.stories.mdx
@@ -17,10 +17,10 @@ export const StoryWithControls = args => {
     <sb-zen-button @click="${showModal}">Show Editor</sb-zen-button>
     <sb-zen-modal
       id="modal1"
-      @cancel="${e => {
+      @zenCancel="${e => {
         e.target.show = false;
       }}"
-      @ok="${e => {
+      @zenOk="${e => {
         e.target.show = false;
       }}"
       ...="${spreadArgs(args, argTypes)}"
@@ -54,7 +54,7 @@ export const StoryMultipleModals = () => {
       <sb-zen-button @click="${showEditor}">Show Editor</sb-zen-button>
       <sb-zen-button @click="${showConfirm}">Show Confirmation</sb-zen-button>
     </sb-zen-space>
-    <sb-zen-modal id="editor" label="Risk score editor" @cancel="${closeEditor}">
+    <sb-zen-modal id="editor" label="Risk score editor" @zenCancel="${closeEditor}">
       <sb-zen-text>This is a modal window editor example.</sb-zen-text>
       <sb-zen-space spacing="sm" vertical>
         <sb-zen-text variant="label" required>Username</sb-zen-text>
@@ -72,10 +72,10 @@ export const StoryMultipleModals = () => {
     <sb-zen-modal
       id="confirm"
       label="Confirmation"
-      @cancel="${e => {
+      @zenCancel="${e => {
         e.target.show = false;
       }}"
-      @ok="${e => {
+      @zenOk="${e => {
         e.target.show = false;
       }}"
     >

--- a/src/components/zen-modal/zen-modal.tsx
+++ b/src/components/zen-modal/zen-modal.tsx
@@ -28,10 +28,10 @@ export class ZenModal {
   @Prop() readonly hideCancel: boolean = false;
 
   /** Top-right X button or default Cancel button clicked */
-  @Event() cancel: EventEmitter<void>;
+  @Event() zenCancel: EventEmitter<void>;
 
   /** Default Ok button clicked (irrelevant if slot `buttons` passed) */
-  @Event() ok: EventEmitter<void>;
+  @Event() zenOk: EventEmitter<void>;
 
   /** Padding of header */
   @Prop() readonly headerPadding: SpacingShorthand = 'lg xl';
@@ -52,11 +52,11 @@ export class ZenModal {
   }
 
   onCancelClicked(): void {
-    this.cancel.emit();
+    this.zenCancel.emit();
   }
 
   onOkClicked(): void {
-    this.ok.emit();
+    this.zenOk.emit();
   }
 
   async componentDidRender(): Promise<void> {

--- a/src/components/zen-panel/test/zen-panel.spec.tsx
+++ b/src/components/zen-panel/test/zen-panel.spec.tsx
@@ -59,11 +59,11 @@ describe('zen-panel', () => {
       expect(helpers.hideWithAnimation).toHaveBeenCalled();
     });
 
-    it('should emit "open" event', async () => {
+    it('should emit "zenOpen" event', async () => {
       await render();
 
       const eventSpy = jest.fn();
-      panel.addEventListener('open', eventSpy);
+      panel.addEventListener('zenOpen', eventSpy);
 
       panel.visible = true;
       await page.waitForChanges();
@@ -71,12 +71,12 @@ describe('zen-panel', () => {
       expect(eventSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should emit "close" event', async () => {
+    it('should emit "zenClose" event', async () => {
       await render('visible');
       expect(panel.visible).toBe(true);
 
       const eventSpy = jest.fn();
-      panel.addEventListener('close', eventSpy);
+      panel.addEventListener('zenClose', eventSpy);
 
       panel.visible = false;
       await page.waitForChanges();

--- a/src/components/zen-panel/zen-panel.stories.mdx
+++ b/src/components/zen-panel/zen-panel.stories.mdx
@@ -11,11 +11,11 @@ const argTypes = getArgTypes(compData);
 
 export const StoryWithControls = args => {
   return html/*html*/ `
-    <sb-zen-panel id="wc-panel" ...="${spreadArgs(args, argTypes)}">
+    <sb-zen-panel id="panel-control" ...="${spreadArgs(args, argTypes)}">
       <sb-zen-text slot="header">Panel title</sb-zen-text>
       Content
     </sb-zen-panel>
-    ${logEvents('#wc-panel', getComponentData('zen-panel'))}
+    ${logEvents('#panel-control', getComponentData('zen-panel'))}
   `;
 };
 

--- a/src/components/zen-panel/zen-panel.tsx
+++ b/src/components/zen-panel/zen-panel.tsx
@@ -34,19 +34,19 @@ export class ZenPanel {
   @Prop({ reflect: true }) readonly contentPadding: SpacingShorthand = 'md lg';
 
   /** Panel opened */
-  @Event() open: EventEmitter<void>;
+  @Event() zenOpen: EventEmitter<void>;
 
   /** Panel closed */
-  @Event() close: EventEmitter<void>;
+  @Event() zenClose: EventEmitter<void>;
 
   @Watch('visible')
   async visibleChanged(visible: boolean): Promise<void> {
     if (visible) {
       this.initializing ? showInstantly(this.content) : showWithAnimation(this.content);
-      this.open.emit();
+      this.zenOpen.emit();
     } else {
       this.initializing ? hideInstantly(this.content) : hideWithAnimation(this.content);
-      this.close.emit();
+      this.zenClose.emit();
     }
   }
 

--- a/src/components/zen-popover/zen-popover.stories.mdx
+++ b/src/components/zen-popover/zen-popover.stories.mdx
@@ -3,6 +3,7 @@ import { Meta, Description, Story, Canvas, ArgsTable } from '@storybook/addon-do
 import { faTimes, faTrashAlt, faPlus, faFilter, faCheck } from '@fortawesome/pro-light-svg-icons';
 import { waitForElement } from '#storybook/helpers/utils';
 import { getArgTypesAndArgs, getDefaultArgs, getComponentData, spreadArgs } from '#storybook/helpers/argTypes';
+import { logEvents } from '#storybook/helpers/log-events';
 const { argTypes } = getArgTypesAndArgs('zen-popover');
 
 <Meta title="Containers/Popover" component="zen-popover" argTypes={argTypes} />
@@ -18,6 +19,7 @@ export const StoryWithControls = args => {
         <sb-zen-text size="sm">Lorem Ipsum is simply dummy text of the printing and typesetting industry.</sb-zen-text>
       </sb-zen-popover>
     </sb-zen-space>
+    ${logEvents('#control', getComponentData('zen-popover'))}
   `;
 };
 

--- a/src/components/zen-popover/zen-popover.tsx
+++ b/src/components/zen-popover/zen-popover.tsx
@@ -65,8 +65,8 @@ export class ZenPopover {
   /** Skipped */
   @Prop() readonly paddingLeft: Spacing = null;
 
-  /** Visibility changed */
-  @Event() visibleChange: EventEmitter<void>;
+  /** Zen popover visibility change event */
+  @Event() zenVisibleChange: EventEmitter<void>;
 
   @Watch('visible')
   async visibleChanged(visible: boolean): Promise<void> {
@@ -239,14 +239,14 @@ export class ZenPopover {
     });
     await waitNextFrame();
     this.actualPosition = this.popperInstance.state.placement;
-    this.visibleChange.emit();
+    this.zenVisibleChange.emit();
   }
 
   destroyPopper(): void {
     if (this.popperInstance) {
       this.popperInstance.destroy();
       this.popperInstance = null;
-      this.visibleChange.emit();
+      this.zenVisibleChange.emit();
     }
   }
 

--- a/src/components/zen-progress-tracker/zen-progress-tracker.stories.mdx
+++ b/src/components/zen-progress-tracker/zen-progress-tracker.stories.mdx
@@ -9,7 +9,7 @@ const compData = data.components.find(n => n.tag === 'zen-progress-tracker');
 const argTypes = getArgTypes(compData);
 argTypes['activeIndex'].control = 'number';
 
-<Meta title="Navigation/Progress tracker" component="zen-progress-tracker" argTypes={argTypes} />
+<Meta title="Navigation/Progress Tracker" component="zen-progress-tracker" argTypes={argTypes} />
 
 export const StoryWithControls = args => {
   waitForElement('#tracker', element => {

--- a/src/components/zen-progress-tracker/zen-progress-tracker.tsx
+++ b/src/components/zen-progress-tracker/zen-progress-tracker.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, State, Watch, Element } from '@stencil/core';
+import { Component, Host, h, Prop, State, Watch, Element, Event, EventEmitter } from '@stencil/core';
 import { faCheck } from '@fortawesome/pro-light-svg-icons';
 import { StepsFilter } from './types';
 import cloneDeep from 'lodash/cloneDeep';
@@ -15,10 +15,6 @@ export interface StepEvent {
   index: number;
   step: StepItem;
 }
-
-/**
- * @event change | ActiveIndex changed
- */
 
 @Component({
   tag: 'zen-progress-tracker',
@@ -37,6 +33,8 @@ export class ZenProgressTracker {
   @Prop({ reflect: true }) readonly clickable: StepsFilter = 'completed';
   /** Max label width */
   @Prop({ reflect: true }) readonly labelWidth: string = '8rem';
+  /** Progress tracker change event */
+  @Event() zenChange: EventEmitter<void>;
 
   @Watch('activeIndex')
   activeIndexChanged(activeIndex: number): void {
@@ -46,7 +44,7 @@ export class ZenProgressTracker {
   /** User clicked a step */
   selectStep(index: number): void {
     this.activeIndex = index;
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   }
 
   stepClicked(index: number): void {

--- a/src/components/zen-radio/test/zen-radio.spec.tsx
+++ b/src/components/zen-radio/test/zen-radio.spec.tsx
@@ -78,7 +78,7 @@ describe('zen-radio', () => {
 
   it('should emit "change" event on change', async () => {
     const eventSpy = jest.fn();
-    radios[2].addEventListener('change', eventSpy);
+    radios[2].addEventListener('zenChange', eventSpy);
 
     radios[2].checked = true;
     await page.waitForChanges();
@@ -87,7 +87,7 @@ describe('zen-radio', () => {
 
   it('should emit "change" event on item from same group change', async () => {
     const eventSpy = jest.fn();
-    radios[2].addEventListener('change', eventSpy);
+    radios[2].addEventListener('zenChange', eventSpy);
 
     radios[1].checked = true;
     await page.waitForChanges();

--- a/src/components/zen-radio/zen-radio.tsx
+++ b/src/components/zen-radio/zen-radio.tsx
@@ -1,11 +1,7 @@
-import { Component, Host, h, Prop, Element, Listen, Watch, Method } from '@stencil/core';
+import { Component, Host, h, Prop, Element, Listen, Watch, Method, Event, EventEmitter } from '@stencil/core';
 import { querySelectorAllDeep } from 'query-selector-shadow-dom';
 import last from 'lodash/last';
 import { applyPrefix, toggleAttribute } from '../helpers/helpers';
-
-/**
- * @event change | Called each time radio.selected changes
- */
 
 @Component({
   tag: 'zen-radio',
@@ -36,6 +32,9 @@ export class ZenRadio {
   /** Group id to which this radio belongs */
   @Prop({ reflect: true }) readonly group: string = '';
 
+  /** Radio change event */
+  @Event() zenChange: EventEmitter<void>;
+
   @Watch('checked')
   async checkedChanged(checked: boolean): Promise<void> {
     this.setSelected(checked ? this.value : '');
@@ -46,10 +45,18 @@ export class ZenRadio {
     this.setSelected(selected);
   }
 
+  /**
+   * Method triggers a custom event "zenChange"
+   */
+  @Method()
+  async dispatchChangeEvent(): Promise<void> {
+    this.zenChange.emit();
+  }
+
   setSelected(selected: string): void {
     const dispatchChangeEvents = (): void => {
       this.elementsInSameGroup().forEach((element: HTMLZenRadioElement) => {
-        element.dispatchEvent(new window.Event('change'));
+        element.dispatchChangeEvent();
       });
     };
 

--- a/src/components/zen-sidebar-nav-item/zen-sidebar-nav-item.tsx
+++ b/src/components/zen-sidebar-nav-item/zen-sidebar-nav-item.tsx
@@ -46,6 +46,10 @@ export class ZenSidebarNavItem {
     ) as HTMLZenSidebarNavSubitemElement[];
   }
 
+  validateSubitems(): void {
+    this.hasSubitems = this.getItems().length > 0;
+  }
+
   subitemSelected(event: CustomEvent): void {
     const newlySelected = event.target;
     const others = this.getItems().filter(item => item.selected && item !== newlySelected);
@@ -57,7 +61,7 @@ export class ZenSidebarNavItem {
 
   startChildObserver(): void {
     this.childObserver = new MutationObserver(() => {
-      this.hasSubitems = this.getItems().length > 0;
+      this.validateSubitems();
     });
 
     this.childObserver.observe(this.host, {
@@ -69,6 +73,7 @@ export class ZenSidebarNavItem {
 
   componentDidLoad(): void {
     this.startChildObserver();
+    this.validateSubitems();
   }
 
   disconnectedCallback(): void {

--- a/src/components/zen-sidebar-nav-subitem/zen-sidebar-nav-subitem.stories.mdx
+++ b/src/components/zen-sidebar-nav-subitem/zen-sidebar-nav-subitem.stories.mdx
@@ -3,6 +3,7 @@ import { html } from 'lit-html';
 import { getArgTypes, getDefaultArgs, getComponentData, spreadArgs } from '#storybook/helpers/argTypes';
 import { waitForElement } from '#storybook/helpers/utils';
 import { faHomeAlt } from '@fortawesome/pro-regular-svg-icons';
+import { logEvents } from '#storybook/helpers/log-events';
 
 import data from '../../../stencilDocs.json';
 const compData = data.components.find(n => n.tag === 'zen-sidebar-nav-subitem');
@@ -19,7 +20,10 @@ export const StoryWithControls = args => {
     element.icon = faHomeAlt;
   });
   return html/*html*/ `
-    <sb-zen-sidebar-nav-subitem ...="${spreadArgs(args, argTypes)}"> Controls </sb-zen-sidebar-nav-subitem>
+    <sb-zen-sidebar-nav-subitem id="story-with-ctrls-element" ...="${spreadArgs(args, argTypes)}">
+      Controls
+    </sb-zen-sidebar-nav-subitem>
+    ${logEvents('#story-with-ctrls-element', getComponentData('zen-sidebar-nav-subitem'))}
   `;
 };
 

--- a/src/components/zen-sidebar-nav-subitem/zen-sidebar-nav-subitem.tsx
+++ b/src/components/zen-sidebar-nav-subitem/zen-sidebar-nav-subitem.tsx
@@ -10,12 +10,12 @@ export class ZenSidebarNavSubitem {
   @Prop({ reflect: true }) readonly selected: boolean = false;
 
   /** Item was selected */
-  @Event() subitemSelect: EventEmitter<void>;
+  @Event() zenSubitemSelect: EventEmitter<void>;
 
   @Watch('selected')
   async selectedChanged(selected: boolean): Promise<void> {
     if (!selected) return;
-    this.subitemSelect.emit();
+    this.zenSubitemSelect.emit();
   }
 
   render(): HTMLElement {

--- a/src/components/zen-sidebar-nav/zen-sidebar-nav.stories.mdx
+++ b/src/components/zen-sidebar-nav/zen-sidebar-nav.stories.mdx
@@ -124,7 +124,10 @@ export const StoryWithControls = args => {
         <sb-zen-text size="sm">${loremIpsum(3)}</sb-zen-text>
       </sb-zen-space>
     </sb-zen-space>
-    ${logEvents('#sidebar1', getComponentData('zen-sidebar'))}`;
+    ${logEvents('#sidebar1', getComponentData('zen-sidebar'))} ${logEvents(
+      '#sidebar1',
+      getComponentData('zen-sidebar-nav-subitem'),
+    )} ${logEvents('#sidebar1', getComponentData('zen-sidebar-nav-item'))}`;
 };
 
 # Zen Sidebar navigation

--- a/src/components/zen-sidebar-nav/zen-sidebar-nav.tsx
+++ b/src/components/zen-sidebar-nav/zen-sidebar-nav.tsx
@@ -47,13 +47,12 @@ export class ZenSidebarNav {
     const ZenIcon = applyPrefix('zen-icon', this.host);
 
     return (
-      <Host>
+      <Host onZenSelect={e => this.itemSelected(e)}>
         <ZenSidebar
           class="sidebar"
           collapsed-size={this.collapsedSize}
           expanded={this.expanded}
-          onZenSelect={e => this.itemSelected(e)}
-          onToggle={e => this.onToggle(e)}
+          onZenToggle={e => this.onToggle(e)}
         >
           <slot></slot>
           <slot name="footer"></slot>

--- a/src/components/zen-sidebar/zen-sidebar.stories.mdx
+++ b/src/components/zen-sidebar/zen-sidebar.stories.mdx
@@ -20,7 +20,7 @@ export const Template = args => {
       style="border: 1px solid lightgrey; position:relative; height: 400px"
     >
       <sb-zen-sidebar
-        @collapse="${e => {
+        @zenCollapse="${e => {
           e.target.expanded = false;
         }}"
         style="${placeAfter ? 'order: 2' : ''}"

--- a/src/components/zen-sidebar/zen-sidebar.tsx
+++ b/src/components/zen-sidebar/zen-sidebar.tsx
@@ -48,10 +48,10 @@ export class ZenSidebar {
   @Prop() readonly paddingLeft: Spacing = null;
 
   /** Inner sidebar hide button clicked */
-  @Event() collapse: EventEmitter<void>;
+  @Event() zenCollapse: EventEmitter<void>;
 
   /** On sidebar collapse/expand */
-  @Event() toggle: EventEmitter<{ expanded: boolean }>;
+  @Event() zenToggle: EventEmitter<{ expanded: boolean }>;
 
   @Watch('expanded')
   async expandedChanged(): Promise<void> {
@@ -61,7 +61,7 @@ export class ZenSidebar {
 
   isVertical = (): boolean => ['left', 'right'].includes(this.position);
 
-  toggleSidebar(animated = true): void {
+  toggleSidebar(animated = true, triggerEvent = true): void {
     const [sizeProp, offsetProp] = this.isVertical() ? ['width', 'offsetWidth'] : ['height', 'offsetHeight'];
 
     // note: we have to get width in px, because `width: auto` isn't animated
@@ -79,15 +79,15 @@ export class ZenSidebar {
       transition: duration,
     };
 
-    this.toggle.emit({ expanded: expand });
+    if (triggerEvent) this.zenToggle.emit({ expanded: expand });
   }
 
   onCloseClicked(): void {
-    this.collapse.emit();
+    this.zenCollapse.emit();
   }
 
   componentDidLoad(): void {
-    this.toggleSidebar(false);
+    this.toggleSidebar(false, false);
     this.wrapPosition = this.expanded ? 'relative' : 'absolute';
   }
 

--- a/src/components/zen-sortable/test/zen-sortable.spec.tsx
+++ b/src/components/zen-sortable/test/zen-sortable.spec.tsx
@@ -54,6 +54,6 @@ describe('zen-sortable', () => {
     expect(fakeOnEndEvent.target.dispatchEvent).toHaveBeenCalledTimes(1);
     const [[triggerEvent]] = fakeOnEndEvent.target.dispatchEvent.mock.calls;
     expect(triggerEvent.detail).toEqual(dataIds);
-    expect(triggerEvent.type).toBe('onChange');
+    expect(triggerEvent.type).toBe('zenChange');
   });
 });

--- a/src/components/zen-sortable/zen-sortable.tsx
+++ b/src/components/zen-sortable/zen-sortable.tsx
@@ -5,7 +5,6 @@ import { SpacingShorthand, Size, None } from '../helpers/types';
 
 /**
  * @slot defaultSlot - Slot for ex. zen-sortable-item with possibility to set padding and spacing
- * @event onChange | Called on any selection change and returns a list of ids.
  */
 @Component({
   tag: 'zen-sortable',
@@ -32,7 +31,7 @@ export class ZenSortable {
         handle: '.handle',
         onEnd: function (evt) {
           evt.stopPropagation();
-          evt.target.dispatchEvent(new CustomEvent('onChange', { detail: this.toArray() }));
+          evt.target.dispatchEvent(new CustomEvent('zenChange', { detail: this.toArray() }));
         },
       });
     } else {

--- a/src/components/zen-status-tracker/zen-status-tracker.tsx
+++ b/src/components/zen-status-tracker/zen-status-tracker.tsx
@@ -41,6 +41,9 @@ export class ZenStatusTracker {
     const children = this.getChildren();
 
     if (!this.isValid(children)) return;
+    /**
+     * @todo Is this really necessary? The component doesn't have interaction.
+     */
     this.zenChange.emit();
 
     if (this.archived) {

--- a/src/components/zen-tab/zen-tab.tsx
+++ b/src/components/zen-tab/zen-tab.tsx
@@ -12,10 +12,10 @@ export class ZenTab {
   @Prop({ reflect: true }) readonly selected: boolean = false;
 
   /** Tab selected event */
-  @Event() tabSelect: EventEmitter<void>;
+  @Event() zenSelect: EventEmitter<void>;
 
   onClick(): void {
-    this.tabSelect.emit();
+    this.zenSelect.emit();
   }
 
   render(): HTMLZenTabElement {

--- a/src/components/zen-table-cell/zen-table-cell.tsx
+++ b/src/components/zen-table-cell/zen-table-cell.tsx
@@ -71,7 +71,7 @@ export class ZenTableCell {
               indeterminate={this.$indeterminate}
               class={{ checkbox: true, invisible: !this.$selectable }}
               checked={this.$selected}
-              onChange={event => this.onCheckboxClick(event)}
+              onZenChange={event => this.onCheckboxClick(event)}
             />
             <ZenIcon
               class={{ 'expand-icon': true, invisible: !this.$expandable }}

--- a/src/components/zen-table-row/test/zen-table-row.spec.tsx
+++ b/src/components/zen-table-row/test/zen-table-row.spec.tsx
@@ -166,7 +166,7 @@ describe('zen-table-row inside tree structure', () => {
   it('should set indeterminate state to all parent rows', async () => {
     const checkbox = secondDepthCell.shadowRoot.querySelector('.checkbox') as HTMLZenCheckboxElement;
     checkbox.checked = true;
-    const event = new Event('change', { bubbles: true, composed: true });
+    const event = new Event('zenChange', { bubbles: true, composed: true });
     checkbox.dispatchEvent(event);
     await page.waitForChanges();
     cleanupTableStructure(table);

--- a/src/components/zen-table-row/zen-table-row.tsx
+++ b/src/components/zen-table-row/zen-table-row.tsx
@@ -45,7 +45,11 @@ export class ZenTableRow {
   /** Row is placed right after header (auto calculated) */
   @Prop() readonly $afterHeader: boolean = false;
 
-  /** Row selected */
+  /**
+   * Row selected
+   *
+   * @todo Is this really needed?
+   */
   @Event() rowSelectChanged: EventEmitter<boolean>;
 
   @Watch('selectable')

--- a/src/components/zen-tabs/zen-tabs.tsx
+++ b/src/components/zen-tabs/zen-tabs.tsx
@@ -1,8 +1,5 @@
-import { Component, Host, h, Prop, Element, Listen, Watch } from '@stencil/core';
+import { Component, Host, h, Prop, Element, Listen, Watch, Event, EventEmitter } from '@stencil/core';
 
-/**
- * @event change | Called on any selection change
- **/
 @Component({
   tag: 'zen-tabs',
   styleUrl: 'zen-tabs.scss',
@@ -15,6 +12,9 @@ export class ZenTabs {
 
   /** Index of currently selected tab. */
   @Prop() readonly value: number = 0;
+
+  /** Tabs change event */
+  @Event() zenChange: EventEmitter<void>;
 
   @Watch('value')
   async selectedChanged(): Promise<void> {
@@ -32,7 +32,7 @@ export class ZenTabs {
     });
 
     if (tab) tab.selected = true;
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   }
 
   componentDidLoad(): void {

--- a/src/components/zen-tabs/zen-tabs.tsx
+++ b/src/components/zen-tabs/zen-tabs.tsx
@@ -26,18 +26,18 @@ export class ZenTabs {
     this.selectTab(event.target as HTMLZenTabElement);
   }
 
-  selectTab(tab: HTMLZenTabElement): void {
+  selectTab(tab: HTMLZenTabElement, triggerEvent = true): void {
     this.tabs.forEach(n => {
       n.selected = false;
     });
 
     if (tab) tab.selected = true;
-    this.zenChange.emit();
+    if (triggerEvent) this.zenChange.emit();
   }
 
   componentDidLoad(): void {
     this.tabs = Array.from(this.host.children).map(n => n as HTMLZenTabElement);
-    this.selectTab(this.tabs[this.value]);
+    this.selectTab(this.tabs[this.value], false);
   }
 
   render(): HTMLZenTabsElement {

--- a/src/components/zen-tabs/zen-tabs.tsx
+++ b/src/components/zen-tabs/zen-tabs.tsx
@@ -7,18 +7,21 @@ import { Component, Host, h, Prop, Element, Listen, Watch, Event, EventEmitter }
 })
 export class ZenTabs {
   private tabs: HTMLZenTabElement[];
+  private updating = false;
 
   @Element() host: HTMLZenTabsElement;
 
   /** Index of currently selected tab. */
-  @Prop() readonly value: number = 0;
+  @Prop({ mutable: true, reflect: true }) value = 0;
 
   /** Tabs change event */
   @Event() zenChange: EventEmitter<void>;
 
   @Watch('value')
-  async selectedChanged(): Promise<void> {
-    this.selectTab(this.tabs[this.value]);
+  selectedChanged(): void {
+    if (!this.updating) {
+      this.selectTab(this.tabs[this.value]);
+    }
   }
 
   @Listen('zenSelect')
@@ -27,12 +30,18 @@ export class ZenTabs {
   }
 
   selectTab(tab: HTMLZenTabElement, triggerEvent = true): void {
-    this.tabs.forEach(n => {
-      n.selected = false;
+    this.updating = true;
+    this.tabs.forEach((n, index) => {
+      if (tab === n) {
+        n.selected = true;
+        this.value = index;
+      } else {
+        n.selected = false;
+      }
     });
 
-    if (tab) tab.selected = true;
     if (triggerEvent) this.zenChange.emit();
+    this.updating = false;
   }
 
   componentDidLoad(): void {

--- a/src/components/zen-tabs/zen-tabs.tsx
+++ b/src/components/zen-tabs/zen-tabs.tsx
@@ -19,7 +19,7 @@ export class ZenTabs {
 
   @Watch('value')
   selectedChanged(): void {
-    if (!this.updating) {
+    if (!this.updating && !Number.isNaN(this.value)) {
       this.selectTab(this.tabs[this.value]);
     }
   }

--- a/src/components/zen-tabs/zen-tabs.tsx
+++ b/src/components/zen-tabs/zen-tabs.tsx
@@ -21,7 +21,7 @@ export class ZenTabs {
     this.selectTab(this.tabs[this.value]);
   }
 
-  @Listen('tabSelect')
+  @Listen('zenSelect')
   onSelectedTab(event: CustomEvent): void {
     this.selectTab(event.target as HTMLZenTabElement);
   }

--- a/src/components/zen-textarea/zen-textarea.tsx
+++ b/src/components/zen-textarea/zen-textarea.tsx
@@ -1,8 +1,7 @@
-import { Component, Host, h, Prop, Element, Method } from '@stencil/core';
+import { Component, Host, h, Prop, Element, Method, Event, EventEmitter } from '@stencil/core';
 import { Resize } from '../helpers/types';
 
 /**
- * @event change | Content change applied
  * @event input | Content changed
  * @event focus | Focused
  * @event blur | Focus lost
@@ -45,6 +44,9 @@ export class ZenTextarea {
   /** Prefilled text content */
   @Prop({ mutable: true }) text?: string | null = '';
 
+  /** Textarea change event */
+  @Event() zenChange: EventEmitter<void>;
+
   /** Focus input */
   @Method()
   async focusInput(): Promise<void> {
@@ -66,7 +68,7 @@ export class ZenTextarea {
       this.text = input.value || '';
     }
     // change event should be forwarded, because it's not composed:
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   };
 
   render(): HTMLElement {

--- a/src/components/zen-textarea/zen-textarea.tsx
+++ b/src/components/zen-textarea/zen-textarea.tsx
@@ -1,12 +1,6 @@
 import { Component, Host, h, Prop, Element, Method, Event, EventEmitter } from '@stencil/core';
 import { Resize } from '../helpers/types';
 
-/**
- * @event input | Content changed
- * @event focus | Focused
- * @event blur | Focus lost
- */
-
 @Component({
   tag: 'zen-textarea',
   styleUrl: 'zen-textarea.scss',
@@ -47,6 +41,15 @@ export class ZenTextarea {
   /** Textarea change event */
   @Event() zenChange: EventEmitter<void>;
 
+  /** Textarea event */
+  @Event() zenInput: EventEmitter<void>;
+
+  /** Textarea focus event */
+  @Event() zenFocus: EventEmitter<void>;
+
+  /** Textarea blur event */
+  @Event() zenBlur: EventEmitter<void>;
+
   /** Focus input */
   @Method()
   async focusInput(): Promise<void> {
@@ -60,6 +63,8 @@ export class ZenTextarea {
     if (input) {
       this.text = input.value || '';
     }
+    ev.preventDefault();
+    this.zenInput.emit();
   };
 
   private onChange = (ev: Event) => {

--- a/src/components/zen-textarea/zen-textarea.tsx
+++ b/src/components/zen-textarea/zen-textarea.tsx
@@ -76,6 +76,14 @@ export class ZenTextarea {
     this.zenChange.emit();
   };
 
+  private onBlur = () => {
+    this.zenBlur.emit();
+  };
+
+  private onFocus = () => {
+    this.zenFocus.emit();
+  };
+
   render(): HTMLElement {
     const text = this.text;
     const style = { resize: this.resize };
@@ -92,6 +100,8 @@ export class ZenTextarea {
           required={this.required}
           onInput={this.onInput}
           onChange={this.onChange}
+          onBlur={this.onBlur}
+          onFocus={this.onFocus}
         >
           {text}
         </textarea>

--- a/src/components/zen-toggle/test/zen-toggle.spec.tsx
+++ b/src/components/zen-toggle/test/zen-toggle.spec.tsx
@@ -20,7 +20,7 @@ describe('zen-toggle', () => {
     const changeSpy = jest.fn();
 
     page.root.addEventListener('keydown', keyDownSpy);
-    page.root.addEventListener('change', changeSpy);
+    page.root.addEventListener('zenChange', changeSpy);
 
     page.root.dispatchEvent(new KeyboardEvent('keydown', { code: 'Enter' }));
     await page.waitForChanges();
@@ -44,7 +44,7 @@ describe('zen-toggle', () => {
     const changeSpy = jest.fn();
 
     page.root.addEventListener('click', clickSpy);
-    page.root.addEventListener('change', changeSpy);
+    page.root.addEventListener('zenChange', changeSpy);
 
     page.root.dispatchEvent(new MouseEvent('click'));
     await page.waitForChanges();

--- a/src/components/zen-toggle/zen-toggle.tsx
+++ b/src/components/zen-toggle/zen-toggle.tsx
@@ -1,7 +1,6 @@
-import { Component, Host, h, Element, Prop, Watch, State } from '@stencil/core';
+import { Component, Host, h, Element, Prop, Watch, State, Event, EventEmitter } from '@stencil/core';
 
 /**
- * @event change | Checked changed
  * @event click | Element clicked
  */
 
@@ -13,6 +12,9 @@ import { Component, Host, h, Element, Prop, Watch, State } from '@stencil/core';
 export class ZenToggle {
   @Element() host: HTMLZenToggleElement;
 
+  /** Sets if component can be tabbable/focusable. */
+  @State() tabindex = 0;
+
   /** Name of element, can be used as reference for form data */
   @Prop() readonly name: string = '';
 
@@ -22,12 +24,12 @@ export class ZenToggle {
   /** Set checked state. */
   @Prop({ mutable: true }) checked = false;
 
-  /** Sets if component can be tabbable/focusable. */
-  @State() tabindex = 0;
+  /** Toggle change event */
+  @Event() zenChange: EventEmitter<void>;
 
   @Watch('checked')
   checkedChanged(): void {
-    this.host.dispatchEvent(new window.Event('change'));
+    this.zenChange.emit();
   }
 
   @Watch('disabled')

--- a/src/stories/components/html-playground/readme.md
+++ b/src/stories/components/html-playground/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property            | Attribute            | Description                                                | Type          | Default                    |
-| ------------------- | -------------------- | ---------------------------------------------------------- | ------------- | -------------------------- |
-| `saveValue`         | `save-value`         | Save current value to local storage and restore it on load | `boolean`     | `true`                     |
-| `selectedFramework` | `selected-framework` | What framework is initally selected                        | `string`      | `this.frameworks[0].value` |
-| `sourceCodes`       | --                   | What framework is initally selected                        | `SourceCodes` | `DEFAULTS_SOURCES()`       |
+| Property            | Attribute            | Description                                                | Type          | Default              |
+| ------------------- | -------------------- | ---------------------------------------------------------- | ------------- | -------------------- |
+| `saveValue`         | `save-value`         | Save current value to local storage and restore it on load | `boolean`     | `true`               |
+| `selectedFramework` | `selected-framework` | What framework is initally selected                        | `number`      | `0`                  |
+| `sourceCodes`       | --                   | What framework is initally selected                        | `SourceCodes` | `DEFAULTS_SOURCES()` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
All events, except for `click`, now use the `zen` prefix. For example `onChange` is now `onZenChange`.

[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-1978)

#### Description

- Changed all onChange to zenChange events.
- Additionally changed most of other events like onBlur, onFocus, onInput. 

Issues that still remains and have to be looked at:

- [x] Check if an event was missed for a component. There are to much of them :) 
- [x] Some components trigger events 2 times. (zen-calendar, ...)
- [x] Some events are not being triggered or logged. (zen-panel, ...)
- [x] Events that are triggered from a child component, should probably have the element which triggered it included.
- Fixed and tried to improve the tests. But still the coverage for components decreased because of the event changes. 

---

Changes by homer0:

- I added checkboxes to Mihael comments because I went through all the components, I checked the events the implemented, the events the listened for and if Storybook was logging them. Thanks to this I was able to fix a couple of things that were already on `main`, like missing mutation on the `zen-tabs` and missing `logEvents` on the `zen-popover` stories.
- The date picker was triggering twice because it was also triggering the `zen-input` events; I stopped the propagation of the those events.
- I changed the target of the branch to a feature branch because I want to fix a couple of types so the implementation can properly do `event.target` without the need of casting to the element they know triggered the event.
