### PR TITLE
PLAT-1977: Export helper types & add missing annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/custom-elements/index.js",
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/interface.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/zen-ui/zen-ui.js",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -47,7 +47,7 @@ export namespace Components {
         /**
           * Save current value to local storage and restore it on load
          */
-        "saveValue": true;
+        "saveValue": boolean;
         /**
           * What framework is initally selected
          */
@@ -205,7 +205,7 @@ export namespace Components {
         /**
           * Disables card.
          */
-        "disabled": false;
+        "disabled": boolean;
         /**
           * <Description generated in helper file>
          */
@@ -239,7 +239,7 @@ export namespace Components {
         /**
           * Disables checkbox.
          */
-        "disabled": false;
+        "disabled": boolean;
         /**
           * Shows the checkbox in indeterminate state
          */
@@ -255,7 +255,7 @@ export namespace Components {
         /**
           * Shows a red asterisk after label.
          */
-        "required": false;
+        "required": boolean;
     }
     interface ZenDatePicker {
         /**
@@ -289,11 +289,11 @@ export namespace Components {
         /**
           * Shows invalid styles
          */
-        "invalid": false;
+        "invalid": boolean;
         /**
           * Placeholder
          */
-        "placeholder": "Select date";
+        "placeholder": string;
         /**
           * Size variant
          */
@@ -309,7 +309,7 @@ export namespace Components {
         /**
           * Is drawer visible
          */
-        "opened": false;
+        "opened": boolean;
         /**
           * <Description generated in helper file>
          */
@@ -339,11 +339,11 @@ export namespace Components {
         /**
           * Don't draw border around field
          */
-        "borderless": false;
+        "borderless": boolean;
         /**
           * Close dropdown menu after selecting an item
          */
-        "closeOnSelect": true;
+        "closeOnSelect": boolean;
         /**
           * Disable any changes
          */
@@ -355,7 +355,7 @@ export namespace Components {
         /**
           * Shows invalid styles.
          */
-        "invalid": false;
+        "invalid": boolean;
         /**
           * To determine if there's enough space under field on open
          */
@@ -419,15 +419,15 @@ export namespace Components {
         /**
           * Should display clear button if focused and not empty
          */
-        "clearButton": true;
+        "clearButton": boolean;
         /**
           * Disables input.
          */
-        "disabled": false;
+        "disabled": boolean;
         /**
           * Focus next control when pressing Enter key
          */
-        "enterToTab": true;
+        "enterToTab": boolean;
         /**
           * Focus input
          */
@@ -435,11 +435,11 @@ export namespace Components {
         /**
           * Paint focused border
          */
-        "hasFocus": false;
+        "hasFocus": boolean;
         /**
           * Shows invalid styles.
          */
-        "invalid": false;
+        "invalid": boolean;
         /**
           * Name of element, can be used as reference for form data
          */
@@ -495,7 +495,7 @@ export namespace Components {
         /**
           * Set `true` to show and `false` to hide modal
          */
-        "show": false;
+        "show": boolean;
     }
     interface ZenNotification {
         /**
@@ -693,7 +693,7 @@ export namespace Components {
         /**
           * Radio can't be selected (but you can still set `checked=true`)
          */
-        "disabled": false;
+        "disabled": boolean;
         /**
           * Group id to which this radio belongs
          */
@@ -705,7 +705,7 @@ export namespace Components {
         /**
           * Shows a red asterisk after label
          */
-        "required": false;
+        "required": boolean;
         /**
           * Value of selected radio in this group
          */
@@ -975,7 +975,7 @@ export namespace Components {
         /**
           * Shows a red asterisk at the end
          */
-        "required": false;
+        "required": boolean;
         /**
           * Font size
          */
@@ -1013,7 +1013,7 @@ export namespace Components {
         /**
           * Appends attribute disabled.
          */
-        "disabled": false;
+        "disabled": boolean;
         /**
           * Focus input
          */
@@ -1021,7 +1021,7 @@ export namespace Components {
         /**
           * Shows invalid styles.
          */
-        "invalid": false;
+        "invalid": boolean;
         /**
           * Name of element, can be used as reference for form data
          */
@@ -1033,7 +1033,7 @@ export namespace Components {
         /**
           * Appends attribute required.
          */
-        "required": false;
+        "required": boolean;
         /**
           * Resize (variants)
          */
@@ -1055,7 +1055,7 @@ export namespace Components {
         /**
           * Set disabled state.
          */
-        "disabled": false;
+        "disabled": boolean;
         /**
           * Name of element, can be used as reference for form data
          */
@@ -1452,7 +1452,7 @@ declare namespace LocalJSX {
         /**
           * Save current value to local storage and restore it on load
          */
-        "saveValue"?: true;
+        "saveValue"?: boolean;
         /**
           * What framework is initally selected
          */
@@ -1610,7 +1610,7 @@ declare namespace LocalJSX {
         /**
           * Disables card.
          */
-        "disabled"?: false;
+        "disabled"?: boolean;
         /**
           * <Description generated in helper file>
          */
@@ -1644,7 +1644,7 @@ declare namespace LocalJSX {
         /**
           * Disables checkbox.
          */
-        "disabled"?: false;
+        "disabled"?: boolean;
         /**
           * Shows the checkbox in indeterminate state
          */
@@ -1660,7 +1660,7 @@ declare namespace LocalJSX {
         /**
           * Shows a red asterisk after label.
          */
-        "required"?: false;
+        "required"?: boolean;
     }
     interface ZenDatePicker {
         /**
@@ -1690,11 +1690,11 @@ declare namespace LocalJSX {
         /**
           * Shows invalid styles
          */
-        "invalid"?: false;
+        "invalid"?: boolean;
         /**
           * Placeholder
          */
-        "placeholder"?: "Select date";
+        "placeholder"?: string;
         /**
           * Size variant
          */
@@ -1714,7 +1714,7 @@ declare namespace LocalJSX {
         /**
           * Is drawer visible
          */
-        "opened"?: false;
+        "opened"?: boolean;
         /**
           * <Description generated in helper file>
          */
@@ -1744,11 +1744,11 @@ declare namespace LocalJSX {
         /**
           * Don't draw border around field
          */
-        "borderless"?: false;
+        "borderless"?: boolean;
         /**
           * Close dropdown menu after selecting an item
          */
-        "closeOnSelect"?: true;
+        "closeOnSelect"?: boolean;
         /**
           * Disable any changes
          */
@@ -1760,7 +1760,7 @@ declare namespace LocalJSX {
         /**
           * Shows invalid styles.
          */
-        "invalid"?: false;
+        "invalid"?: boolean;
         /**
           * To determine if there's enough space under field on open
          */
@@ -1820,23 +1820,23 @@ declare namespace LocalJSX {
         /**
           * Should display clear button if focused and not empty
          */
-        "clearButton"?: true;
+        "clearButton"?: boolean;
         /**
           * Disables input.
          */
-        "disabled"?: false;
+        "disabled"?: boolean;
         /**
           * Focus next control when pressing Enter key
          */
-        "enterToTab"?: true;
+        "enterToTab"?: boolean;
         /**
           * Paint focused border
          */
-        "hasFocus"?: false;
+        "hasFocus"?: boolean;
         /**
           * Shows invalid styles.
          */
-        "invalid"?: false;
+        "invalid"?: boolean;
         /**
           * Name of element, can be used as reference for form data
          */
@@ -1900,7 +1900,7 @@ declare namespace LocalJSX {
         /**
           * Set `true` to show and `false` to hide modal
          */
-        "show"?: false;
+        "show"?: boolean;
     }
     interface ZenNotification {
         /**
@@ -2094,7 +2094,7 @@ declare namespace LocalJSX {
         /**
           * Radio can't be selected (but you can still set `checked=true`)
          */
-        "disabled"?: false;
+        "disabled"?: boolean;
         /**
           * Group id to which this radio belongs
          */
@@ -2106,7 +2106,7 @@ declare namespace LocalJSX {
         /**
           * Shows a red asterisk after label
          */
-        "required"?: false;
+        "required"?: boolean;
         /**
           * Value of selected radio in this group
          */
@@ -2380,7 +2380,7 @@ declare namespace LocalJSX {
         /**
           * Shows a red asterisk at the end
          */
-        "required"?: false;
+        "required"?: boolean;
         /**
           * Font size
          */
@@ -2418,11 +2418,11 @@ declare namespace LocalJSX {
         /**
           * Appends attribute disabled.
          */
-        "disabled"?: false;
+        "disabled"?: boolean;
         /**
           * Shows invalid styles.
          */
-        "invalid"?: false;
+        "invalid"?: boolean;
         /**
           * Name of element, can be used as reference for form data
          */
@@ -2434,7 +2434,7 @@ declare namespace LocalJSX {
         /**
           * Appends attribute required.
          */
-        "required"?: false;
+        "required"?: boolean;
         /**
           * Resize (variants)
          */
@@ -2456,7 +2456,7 @@ declare namespace LocalJSX {
         /**
           * Set disabled state.
          */
-        "disabled"?: false;
+        "disabled"?: boolean;
         /**
           * Name of element, can be used as reference for form data
          */

--- a/src/components/zen-card/zen-card.tsx
+++ b/src/components/zen-card/zen-card.tsx
@@ -14,7 +14,7 @@ export class ZenCard {
   @Prop({ reflect: true }) readonly variant: CardVariant = 'default';
 
   /** Disables card. */
-  @Prop({ reflect: true }) readonly disabled = false;
+  @Prop({ reflect: true }) readonly disabled: boolean = false;
 
   /** <Description generated in helper file> */
   @Prop() readonly padding: SpacingShorthand = 'lg';

--- a/src/components/zen-checkbox/zen-checkbox.tsx
+++ b/src/components/zen-checkbox/zen-checkbox.tsx
@@ -20,13 +20,13 @@ export class ZenCheckbox {
   @Prop({ mutable: true }) checked = false;
 
   /** Disables checkbox. */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /** Label of the checkbox. */
   @Prop() readonly label: string = '';
 
   /** Shows a red asterisk after label. */
-  @Prop() readonly required = false;
+  @Prop() readonly required: boolean = false;
 
   /** Shows the checkbox in indeterminate state */
   @Prop({ mutable: true }) indeterminate = false;

--- a/src/components/zen-date-picker/zen-date-picker.tsx
+++ b/src/components/zen-date-picker/zen-date-picker.tsx
@@ -58,7 +58,7 @@ export class ZenDatePicker {
   @Prop({ mutable: true }) formattedDate: string | null = null;
 
   /** Placeholder */
-  @Prop() readonly placeholder = 'Select date';
+  @Prop() readonly placeholder: string = 'Select date';
 
   /** Date format */
   @Prop({ mutable: true }) format = 'MM/dd/yyyy';
@@ -73,7 +73,7 @@ export class ZenDatePicker {
   @Prop() readonly allowEmpty: boolean = true;
 
   /** Shows invalid styles */
-  @Prop() readonly invalid = false;
+  @Prop() readonly invalid: boolean = false;
 
   /** Disables all dates before this one */
   @Prop() readonly disableBeforeDate: string | null = null;

--- a/src/components/zen-drawer/zen-drawer.tsx
+++ b/src/components/zen-drawer/zen-drawer.tsx
@@ -15,7 +15,7 @@ export class ZenDrawer {
   @Element() host: HTMLZenDrawerElement;
 
   /** Is drawer visible */
-  @Prop({ reflect: true }) readonly opened = false;
+  @Prop({ reflect: true }) readonly opened: boolean = false;
 
   /** Position */
   @Prop({ reflect: true }) readonly position: Position = 'right';

--- a/src/components/zen-dropdown/zen-dropdown.tsx
+++ b/src/components/zen-dropdown/zen-dropdown.tsx
@@ -47,10 +47,10 @@ export class ZenDropdown {
   @Prop() readonly menuHeight: string = '170px';
 
   /** Close dropdown menu after selecting an item */
-  @Prop() readonly closeOnSelect = true;
+  @Prop() readonly closeOnSelect: boolean = true;
 
   /** Don't draw border around field */
-  @Prop() readonly borderless = false;
+  @Prop() readonly borderless: boolean = false;
 
   /** Text in field if nothing selected */
   @Prop() readonly placeholder: string = 'Select something';
@@ -59,7 +59,7 @@ export class ZenDropdown {
   @Prop() readonly disabled?: boolean = false;
 
   /** Shows invalid styles. */
-  @Prop() readonly invalid = false;
+  @Prop() readonly invalid: boolean = false;
 
   /** Close an opened dropdown menu */
   @Method()

--- a/src/components/zen-input/zen-input.tsx
+++ b/src/components/zen-input/zen-input.tsx
@@ -30,22 +30,22 @@ export class ZenInput {
   @Prop() readonly name: string = '';
 
   /** Paint focused border */
-  @Prop() readonly hasFocus = false;
+  @Prop() readonly hasFocus: boolean = false;
 
   /** Placeholder of the input. */
   @Prop() readonly placeholder: string = '';
 
   /** Disables input. */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /** Shows invalid styles. */
-  @Prop() readonly invalid = false;
+  @Prop() readonly invalid: boolean = false;
 
   /** Focus next control when pressing Enter key */
-  @Prop() readonly enterToTab = true;
+  @Prop() readonly enterToTab: boolean = true;
 
   /** Should display clear button if focused and not empty */
-  @Prop({ reflect: true }) readonly clearButton = true;
+  @Prop({ reflect: true }) readonly clearButton: boolean = true;
 
   /** The value of the input. */
   @Prop({ mutable: true }) value?: string = '';

--- a/src/components/zen-modal/zen-modal.tsx
+++ b/src/components/zen-modal/zen-modal.tsx
@@ -19,7 +19,7 @@ export class ZenModal {
   @Element() host: HTMLZenModalElement;
 
   /** Set `true` to show and `false` to hide modal */
-  @Prop({ reflect: true }) readonly show = false;
+  @Prop({ reflect: true }) readonly show: boolean = false;
 
   /** Modal title (irrelevant if slot `header` passed) */
   @Prop() readonly label: string = 'Zen-UI modal window';

--- a/src/components/zen-radio/zen-radio.tsx
+++ b/src/components/zen-radio/zen-radio.tsx
@@ -28,10 +28,10 @@ export class ZenRadio {
   @Prop() readonly selected: string = '';
 
   /** Shows a red asterisk after label */
-  @Prop() readonly required = false;
+  @Prop() readonly required: boolean = false;
 
   /** Radio can't be selected (but you can still set `checked=true`) */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /** Group id to which this radio belongs */
   @Prop({ reflect: true }) readonly group: string = '';

--- a/src/components/zen-text/zen-text.tsx
+++ b/src/components/zen-text/zen-text.tsx
@@ -50,7 +50,7 @@ export class ZenText {
   @Prop({ reflect: true }) readonly disabled: boolean = false;
 
   /** Shows a red asterisk at the end */
-  @Prop({ reflect: true }) readonly required = false;
+  @Prop({ reflect: true }) readonly required: boolean = false;
 
   render(): HTMLElement {
     return (

--- a/src/components/zen-textarea/zen-textarea.tsx
+++ b/src/components/zen-textarea/zen-textarea.tsx
@@ -28,13 +28,13 @@ export class ZenTextarea {
   @Prop({ reflect: true }) readonly rows: number = 5;
 
   /** Appends attribute disabled. */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /** Appends attribute required. */
-  @Prop() readonly required = false;
+  @Prop() readonly required: boolean = false;
 
   /** Shows invalid styles. */
-  @Prop({ reflect: true }) readonly invalid = false;
+  @Prop({ reflect: true }) readonly invalid: boolean = false;
 
   /** Placeholder of the textarea. */
   @Prop() readonly placeholder: string = null;

--- a/src/components/zen-toggle/zen-toggle.tsx
+++ b/src/components/zen-toggle/zen-toggle.tsx
@@ -17,7 +17,7 @@ export class ZenToggle {
   @Prop() readonly name: string = '';
 
   /** Set disabled state. */
-  @Prop({ reflect: true }) readonly disabled = false;
+  @Prop({ reflect: true }) readonly disabled: boolean = false;
 
   /** Set checked state. */
   @Prop({ mutable: true }) checked = false;

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -1,0 +1,2 @@
+export * from './components';
+export * from './components/helpers/types';

--- a/src/stories/components/html-playground/html-playground.tsx
+++ b/src/stories/components/html-playground/html-playground.tsx
@@ -66,7 +66,7 @@ export class HtmlPlayground {
   @State() textValue = '';
 
   /** Save current value to local storage and restore it on load */
-  @Prop() readonly saveValue = true;
+  @Prop() readonly saveValue: boolean = true;
 
   /** What framework is initally selected */
   @Prop({ mutable: true }) selectedFramework: string = this.frameworks[0].value;


### PR DESCRIPTION
> I didn't assign anyone because it was friday night; If you are reviewing this on monday morning and there's no one assigned, please add the missing reviewers, thanks!

[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-1977)

#### Description

It copies the implementation of [Ionic core repository](https://github.com/ionic-team/ionic-framework/tree/master/core) for publishing helper types.

With this change, implementation can import types like `AvatarData` directly from `@reciprocity/zen-ui`:

```diff
- import { AvatarData } from '@reciprocity/zen-ui/dist/types/components/helpers/types';
+ import { AvatarData } from '@reciprocity/zen-ui';
```

Since this PR was so small (the first commit), I took the opportunity and added all the missing type annotations for components props; apparently, if a prop has `readonly` and doesn't have a type annotation, the `component.d.ts` uses its default value as a constant for its type, you can see it [here](https://github.com/reciprocity/zen-ui/blob/main/src/components.d.ts#L339-L346) and [here](https://github.com/reciprocity/zen-ui/blob/main/src/components.d.ts#L1693-L1697).