### PR TITLE
Properly type props of components used within other components

### DIFF
--- a/src/components/helpers/helpers.ts
+++ b/src/components/helpers/helpers.ts
@@ -55,11 +55,11 @@ export function toggleAttribute(element: Element, attribute: string, value: stri
   }
 }
 
-export function applyPrefix(componentName: string, parentElement: Element): string {
+export const applyPrefix = <T extends string>(componentName: T, parentElement: Element): T => {
   const parentPrefix = parentElement.tagName.split('-')[0].toLowerCase();
   const sanitizedPrefix = parentPrefix !== 'zen' ? `${parentPrefix}-` : '';
-  return `${sanitizedPrefix}${componentName}`;
-}
+  return `${sanitizedPrefix}${componentName}` as T;
+};
 
 export function parsePadding(padding: string): Record<string, unknown> {
   let paddingClasses: Record<string, unknown> = {};

--- a/src/components/helpers/types.ts
+++ b/src/components/helpers/types.ts
@@ -1,3 +1,5 @@
+export type { Placement, Offsets } from '@popperjs/core';
+
 // Props:
 export type Align = 'left' | 'right' | 'center';
 

--- a/src/components/zen-avatar-details/zen-avatar-details.tsx
+++ b/src/components/zen-avatar-details/zen-avatar-details.tsx
@@ -1,6 +1,13 @@
 import { Component, Host, h, Element, Prop } from '@stencil/core';
 import { applyPrefix } from '../helpers/helpers';
-import { AvatarDetailVariant, AvatarVariantSizes, Spacing, SpacingShorthand } from '../helpers/types';
+import {
+  AvatarDetailVariant,
+  AvatarIconSize,
+  AvatarVariantSizes,
+  Spacing,
+  SpacingShorthand,
+  TextSize,
+} from '../helpers/types';
 
 @Component({
   tag: 'zen-avatar-details',
@@ -91,11 +98,11 @@ export class ZenAvatarDetails {
             initials={this.initials}
             color={this.iconColor}
             background={this.iconBackground}
-            size={sizes.avatarIconSize}
+            size={sizes.avatarIconSize as AvatarIconSize}
             data-test="avatar-icon"
           />
           <ZenSpace no-wrap vertical padding="xs" spacing="sm">
-            <ZenText size={sizes.textSize} bold={sizes.userNameBold} data-test="username">
+            <ZenText size={sizes.textSize as TextSize} bold={sizes.userNameBold} data-test="username">
               {this.userName}
             </ZenText>
             {this.variant === 'detailed' && (

--- a/src/components/zen-avatar-group/zen-avatar-group.tsx
+++ b/src/components/zen-avatar-group/zen-avatar-group.tsx
@@ -77,7 +77,7 @@ export class ZenAvatarGroup {
         {this.shownUsers().map(user => (
           <ZenAvatar users={[user]} animation={this.users.length > 1 && this.animation} />
         ))}
-        {this.hiddenUsers().length > 0 ? <ZenAvatar users={this.hiddenUsers()} animation="false" /> : null}
+        {this.hiddenUsers().length > 0 ? <ZenAvatar users={this.hiddenUsers()} animation={false} /> : null}
       </Host>
     );
   }

--- a/src/components/zen-avatar/zen-avatar.tsx
+++ b/src/components/zen-avatar/zen-avatar.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, Element } from '@stencil/core';
 import { applyPrefix } from '../helpers/helpers';
-import { AvatarData } from '../helpers/types';
+import { AvatarData, AvatarIconSize } from '../helpers/types';
 
 @Component({
   tag: 'zen-avatar',
@@ -55,10 +55,9 @@ export class ZenAvatar {
           initials={this.initials()}
           background={this.background()}
           color={this.color()}
-          size={this.size()}
+          size={this.size() as AvatarIconSize}
         />
         <ZenTooltip
-          variant="light"
           padding="none"
           show-delay="0"
           max-height={this.users.length > 4 ? '250px' : null}

--- a/src/components/zen-button/zen-button.tsx
+++ b/src/components/zen-button/zen-button.tsx
@@ -59,10 +59,10 @@ export class ZenButton {
     const ZenSpinner = applyPrefix('zen-spinner', this.host);
     const spinnerStyle = {
       position: 'absolute',
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0,
+      top: '0',
+      right: '0',
+      bottom: '0',
+      left: '0',
     };
     return (
       <Host class={{ btn: true, [`${this.variant}`]: true, disabled: this.disabled }} tabindex={this.tabindex}>

--- a/src/components/zen-date-picker/tests/zen-date-picker.spec.tsx
+++ b/src/components/zen-date-picker/tests/zen-date-picker.spec.tsx
@@ -251,7 +251,7 @@ describe('zen-date-picker', () => {
     await page.waitForChanges();
     const numbers = calendar.querySelectorAll('.day-num');
     const disabledDays = Array.from(numbers).filter(el => {
-      return el.getAttribute('disabled') && !el.classList.contains('empty');
+      return el.getAttribute('disabled') !== null && !el.classList.contains('empty');
     });
     expect(disabledDays.length).toEqual(5);
   });
@@ -262,7 +262,7 @@ describe('zen-date-picker', () => {
     await page.waitForChanges();
     const numbers = calendar.querySelectorAll('.day-num');
     const disabledDays = Array.from(numbers).filter(el => {
-      return el.getAttribute('disabled') && !el.classList.contains('empty');
+      return el.getAttribute('disabled') !== null && !el.classList.contains('empty');
     });
     expect(disabledDays.length).toEqual(16);
   });

--- a/src/components/zen-date-picker/zen-date-picker.tsx
+++ b/src/components/zen-date-picker/zen-date-picker.tsx
@@ -296,7 +296,7 @@ export class ZenDatePicker {
           interactive
           position="bottom-start"
           close-on-target-click="false"
-          onZenVisibleChange={e => this.onOpenToggle(e.target)}
+          onZenVisibleChange={e => this.onOpenToggle(e.target as HTMLZenPopoverElement)}
         >
           <ZenSpace class="navigation" spacing="sm" padding="sm lg" horizontal-align="center" vertical-align="stretch">
             <ZenIcon
@@ -347,7 +347,7 @@ export class ZenDatePicker {
                     'day-num': true,
                     empty: !num,
                   }}
-                  disabled="true"
+                  disabled
                   align="center"
                 >
                   {num || ''}

--- a/src/components/zen-dropdown/zen-dropdown.tsx
+++ b/src/components/zen-dropdown/zen-dropdown.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, State, Listen, Watch, Element, Method, Event,
 import { getDefaultSlotContent, applyPrefix, scrollIntoView } from '../helpers/helpers';
 import { faChevronDown } from '@fortawesome/pro-light-svg-icons';
 import { OptionValue } from '../zen-menu-item/zen-option';
-import { Align, DropdownSize } from '../helpers/types';
+import { Align, DropdownSize, Placement, TextSize } from '../helpers/types';
 
 export interface OptionItem {
   label: string;
@@ -300,7 +300,7 @@ export class ZenDropdown {
           </div>
           <div class={{ hidden: !!this.value }}>
             <slot name="placeholder">
-              <ZenText class="placeholder" size={this.size}>
+              <ZenText class="placeholder" size={this.size as TextSize}>
                 {this.placeholder}
               </ZenText>
             </slot>
@@ -312,7 +312,7 @@ export class ZenDropdown {
           tabindex={this.opened ? 0 : -1}
           ref={el => (this.popover = el)}
           interactive
-          position={align}
+          position={align as Placement}
           onZenVisibleChange={() => this.onOpenToggle()}
           style={{ width: this.menuWidth, 'max-height': this.menuHeight }}
           offset={offset}

--- a/src/components/zen-input/zen-input.tsx
+++ b/src/components/zen-input/zen-input.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, Element, Listen, State, Method, Watch, Event,
 import { getNextField } from '../helpers/helpers';
 import { faTimes } from '@fortawesome/pro-regular-svg-icons';
 import { applyPrefix } from '../helpers/helpers';
-import { InputSize } from '../helpers/types';
+import { IconSize, InputSize } from '../helpers/types';
 
 /**
  * @slot leadingSlot - Slot placed at the left
@@ -154,8 +154,8 @@ export class ZenInput {
             class="icon clear"
             role="button"
             icon={faTimes}
-            size={this.clearIconSize()}
-            onMousedown={(event: MouseEvent) => this.onClearClick(event)}
+            size={this.clearIconSize() as IconSize}
+            onMouseDown={(event: MouseEvent) => this.onClearClick(event)}
           ></ZenIcon>
         )}
         <slot name="trailingSlot"></slot>

--- a/src/components/zen-tooltip/zen-tooltip.tsx
+++ b/src/components/zen-tooltip/zen-tooltip.tsx
@@ -82,7 +82,7 @@ export class ZenTooltip {
           }}
           offset={{ x: 0, y: this.offset }}
           delay={this.delay}
-          interactive={this.link || isScrollable}
+          interactive={!!this.link || isScrollable}
           padding={this.padding}
           padding-top={this.paddingTop}
           padding-right={this.paddingRight}


### PR DESCRIPTION
#### Description

The original scope of this branch was to be a follow up for #330 and add a new type of `EventEmitter` that would allow us to specific the `event.target` from the component itself:

```ts
export interface ZenCustomEvent<E extends EventTarget = EventTarget, T = void> extends CustomEvent<T> {
  target: E;
}

export interface ZenEventEmitter<E extends EventTarget = EventTarget, T = void> {
  emit: (data?: T) => ZenCustomEvent<E, T>;
}

// ZenEventEmitter<HTMLZenCheckboxElement>
// That would type `event.target` as the checkbox without the need to re cast it to access its `value` prop.
```

It looks wonderful, and it works inside `zen-ui`, but... Stencil ignores it when generating the `components.d.ts` 😭 - so, no way to use.

But why did I create a PR? Well, while working on these types, I found out that by changing the signature of `applyPrefix` a little bit, we could get type validations (and intellisense) on all the components we were using inside `zen-ui`.

The moment I changed it, it already alterted me of (real) invalid types (`string` as `boolean`), invalid props (`onMousedown` instead of `onMouseDown`) and deprecated props (tooltip's `variant`).

Enjoy!

> Note: I added the info about the `ZenEventEmitter` because I wanted to document it somewhere in case we can implement it in the future.
