### PR TITLE
PLAT-2080: Sidebar navigation > submenu options are not deselected when choosing other option

### DIFF
--- a/src/components/zen-sidebar-nav-item/zen-sidebar-nav-item.tsx
+++ b/src/components/zen-sidebar-nav-item/zen-sidebar-nav-item.tsx
@@ -84,7 +84,7 @@ export class ZenSidebarNavItem {
     const ZenIcon = applyPrefix('zen-icon', this.host);
 
     return (
-      <Host onSubitemSelect={e => this.subitemSelected(e)} class={{ 'has-subitems': this.hasSubitems }}>
+      <Host onZenSubitemSelect={e => this.subitemSelected(e)} class={{ 'has-subitems': this.hasSubitems }}>
         <div class="item">
           <slot></slot>
           <ZenIcon class="arrow" size="sm" icon={faChevronDown}></ZenIcon>


### PR DESCRIPTION
- event handler should be prefixed by `zen` prefix

[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-2080)
