### PR TITLE
PLAT-2101: Bug: Status tracker observer loops infinitely

### DIFF
--- a/src/components/helpers/helpers.ts
+++ b/src/components/helpers/helpers.ts
@@ -139,3 +139,8 @@ export function htmlToElement(html: string): Element[] {
   template.innerHTML = html.trim();
   return Array.from(template.content.children);
 }
+
+export const safeSetAttribute = (element: Element, attr: string, value: string): void => {
+  if (element.getAttribute(attr) === value) return;
+  element.setAttribute(attr, value);
+};

--- a/src/components/zen-status-tracker/zen-status-tracker.tsx
+++ b/src/components/zen-status-tracker/zen-status-tracker.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Element, Prop, Event, EventEmitter } from '@stencil/core';
-import { applyPrefix } from '../helpers/helpers';
+import { applyPrefix, safeSetAttribute } from '../helpers/helpers';
 
 @Component({
   tag: 'zen-status-tracker',
@@ -57,17 +57,17 @@ export class ZenStatusTracker {
 
     const lastChild = children[children.length - 1];
     children.reduce((hasSelected, lozenge) => {
-      lozenge.setAttribute('size', 'lg');
+      safeSetAttribute(lozenge, 'size', 'lg');
       const isSelected = this.selectedId === lozenge.id;
       if (isSelected) {
         hasSelected = true;
-        lozenge.setAttribute('variant', lozenge.id === lastChild.id ? 'green' : 'dark-blue-ghost');
+        safeSetAttribute(lozenge, 'variant', lozenge.id === lastChild.id ? 'green' : 'dark-blue-ghost');
       } else {
-        lozenge.setAttribute('variant', 'none');
+        safeSetAttribute(lozenge, 'variant', 'none');
       }
 
       // Every lozenge after selected is "disabled"
-      if (hasSelected && !isSelected) lozenge.setAttribute('disabled', '');
+      if (hasSelected && !isSelected) safeSetAttribute(lozenge, 'disabled', '');
 
       // Remove left border if previous lozenge is selected
       const previousElement = lozenge.previousElementSibling;


### PR DESCRIPTION
- setAttribute always triggers observer callback.
- added a check to set it only if it actually differs.

[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-2101)

Takeaway:
Always test observers by mutating children in manually from the dev tools.

To discuss:
Could we add unit tests to test such behaviour?