### PR TITLE
PLAT-2309: Fix display of initials if username contains on…

### DIFF
--- a/src/components/zen-avatar-icon/test/zen-avatar-icon.spec.tsx
+++ b/src/components/zen-avatar-icon/test/zen-avatar-icon.spec.tsx
@@ -7,8 +7,8 @@ describe('zen-avatar-icon', () => {
       components: [ZenAvatarIcon],
       html: `<zen-avatar-icon user-name="Mike Anderson"></zen-avatar-icon>`,
     });
-    expect(page.root.shadowRoot.querySelector('img').classList.contains('hidden')).toBe(true);
-    expect(page.root.shadowRoot.querySelector('div').classList.contains('hidden')).toBe(false);
+    expect(page.root.shadowRoot.querySelector('img')).toBeFalsy();
+    expect(page.root.shadowRoot.querySelector('.initials')).toBeTruthy();
   });
 
   it('should show image and hide label', async () => {
@@ -16,9 +16,8 @@ describe('zen-avatar-icon', () => {
       components: [ZenAvatarIcon],
       html: `<zen-avatar-icon image-url="img.jpg"></zen-avatar-icon>`,
     });
-    expect(page.root.shadowRoot.querySelector('div').textContent).toEqual('');
-    expect(page.root.shadowRoot.querySelector('img').classList.contains('hidden')).toBe(false);
-    expect(page.root.shadowRoot.querySelector('div').classList.contains('hidden')).toBe(true);
+    expect(page.root.shadowRoot.querySelector('.initials')).toBeFalsy();
+    expect(page.root.shadowRoot.querySelector('img')).toBeTruthy();
   });
 
   it('should correctly display initials if has first and last name', async () => {

--- a/src/components/zen-avatar-icon/zen-avatar-icon.tsx
+++ b/src/components/zen-avatar-icon/zen-avatar-icon.tsx
@@ -36,7 +36,7 @@ export class ZenAvatarIcon {
     if (this.initials) return this.initials;
 
     let initials = '';
-    if (this.userName) {
+    if (this.userName && this.userName.trim() != '') {
       if (/\s/.test(this.userName)) {
         // Get initials from name and surname
         initials = this.userName
@@ -48,8 +48,10 @@ export class ZenAvatarIcon {
         // Get initials oly from name
         initials = this.userName.substring(0, 2).toUpperCase();
       }
-    } else {
+    } else if (this.email && this.email.trim() != '') {
       initials = this.email.substring(0, 2).toUpperCase();
+    } else {
+      console.error('zen-avatar-icon : Username or email has to have a value!');
     }
     return initials;
   }

--- a/src/components/zen-avatar-icon/zen-avatar-icon.tsx
+++ b/src/components/zen-avatar-icon/zen-avatar-icon.tsx
@@ -28,28 +28,26 @@ export class ZenAvatarIcon {
   /** Icon size   */
   @Prop({ reflect: true }) readonly size: AvatarIconSize = 'md';
 
-  hasImage(): boolean {
-    return this.imageUrl != '';
-  }
-
   getUserInitials(): string {
+    if (this.imageUrl) return;
     if (this.initials) return this.initials;
 
     let initials = '';
-    if (this.userName && this.userName.trim() != '') {
+    if (this.userName.trim()) {
       if (/\s/.test(this.userName)) {
         // Get initials from name and surname
         initials = this.userName
+          .trim()
           .match(/(\b([A-Z]|[a-z]))/g)
           .join('')
           .substring(0, 2)
           .toUpperCase();
       } else {
         // Get initials oly from name
-        initials = this.userName.substring(0, 2).toUpperCase();
+        initials = this.userName.trim().substring(0, 2).toUpperCase();
       }
-    } else if (this.email && this.email.trim() != '') {
-      initials = this.email.substring(0, 2).toUpperCase();
+    } else if (this.email.trim()) {
+      initials = this.email.trim().substring(0, 2).toUpperCase();
     } else {
       console.error('zen-avatar-icon : Username or email has to have a value!');
     }
@@ -59,8 +57,7 @@ export class ZenAvatarIcon {
   render(): HTMLElement {
     return (
       <Host style={{ background: this.background, color: this.color }}>
-        <img class={{ hidden: !this.hasImage() }} src={this.imageUrl} />
-        <div class={{ hidden: this.hasImage(), initials: true }}>{this.getUserInitials()}</div>
+        {this.imageUrl ? <img src={this.imageUrl} /> : <div class="initials">{this.getUserInitials()}</div>}
       </Host>
     );
   }


### PR DESCRIPTION
…ly space

[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/PLAT-2309)

#### Description
As per JIRA ticket

Could reproduce on dev. But dont have single spa set locally yet to properly test. There are possibly two issues : 

1. ~~Issue is because the email for a newly invited user is not set. The avatar component automatically uses email if no username for initials. I dont see the email value it in the console data. Has to be fixed on details page. ~~
Email is set so it must be reason 2.   

2. Also another issue is because it seems it even that we check if(username) and its empty it goes into the condition. String with space is set for the username data. Has to be fixed on details page.

user-name=" "
Will add additional check for space in username and email to avatar icon component. Should fix the issue!
#### ChangeLOG

[Changelog](https://zen-ui.zengrc.com/?path=/docs/changelog--page)


#### Useful links
[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)

[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)

[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)
