### PR TITLE
QUICKFIX(zen-notification): Update close icon position

### DIFF
--- a/src/components/zen-notification/zen-notification.scss
+++ b/src/components/zen-notification/zen-notification.scss
@@ -68,10 +68,9 @@
 
 .close {
   position: absolute;
-  top: 0.9rem;
-  right: 0.9rem;
-  width: 0.6rem;
-  margin: 0.3rem;
+  top: 0;
+  right: 0;
+  margin: 0 0 0 auto;
   cursor: pointer;
   color: $color-gray-400;
 }

--- a/src/components/zen-notification/zen-notification.tsx
+++ b/src/components/zen-notification/zen-notification.tsx
@@ -36,19 +36,18 @@ export class ZenNotification {
     const ZenText = applyPrefix('zen-text', this.host);
     return (
       <Host class={{ hidden: !this.visible }}>
-        <ZenIcon
-          class={{ close: true, hidden: !this.dismissable }}
-          onClick={() => {
-            this.close();
-          }}
-          icon={faTimes}
-          padding="sm"
-        />
         <ZenSpace spacing="sm" padding="sm">
           <ZenIcon class="icon" icon={getIcon(this.variant)} padding="sm" />
           <ZenText bold class="title">
             {this.heading}
           </ZenText>
+          <ZenIcon
+            class={{ close: true, hidden: !this.dismissable }}
+            onClick={() => {
+              this.close();
+            }}
+            icon={faTimes}
+          />
         </ZenSpace>
         <ZenSpace class="content" padding="sm">
           <slot />


### PR DESCRIPTION
#### Description
ZenText was overlapping the close icon for the Notification component. This change fixes that by including the close button inside the ZenSpace and updating it a bit with the styling.

#### ChangeLOG

[Changelog](https://zen-ui.zengrc.com/?path=/docs/changelog--page)


#### Useful links
[Zen UI readme](https://github.com/reciprocity/zen-ui/blob/main/README.md)

[PR review guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/pull_request_reviews.md)

[Git commit guidelines](https://github.com/reciprocity/zengrc/blob/develop/doc/dev_environment_and_process/commit_guidelines.md)
