### PR TITLE
QUICK: zen-notification - Set inner html instead of text

### DIFF
--- a/src/components/zen-notifications-wrapper/zen-notifications-wrapper.tsx
+++ b/src/components/zen-notifications-wrapper/zen-notifications-wrapper.tsx
@@ -26,7 +26,7 @@ export class ZenNotificationsWrapper {
     notificationElement.setAttribute('heading', heading);
     notificationElement.setAttribute('variant', variant);
     notificationElement.setAttribute('dismissable', 'true');
-    notificationElement.innerText = content;
+    notificationElement.innerHTML = content;
 
     const wrapper = global.window.ZenUINotificationsWrapper || this.host;
     wrapper.appendChild(notificationElement);


### PR DESCRIPTION
Marko needs to insert link into notification:
![image](https://user-images.githubusercontent.com/5729421/122532143-8131fd80-d020-11eb-8fcb-54f1d5208a97.png)
